### PR TITLE
[feat] 크래시 방지 처리 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,13 +18,19 @@
         tools:targetApi="31">
         <activity
             android:name=".presentation.MainActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:screenOrientation="portrait"
+            tools:ignore="LockedOrientationActivity" />
         <activity
             android:name=".presentation.detail.GoalDetailActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:screenOrientation="portrait"
+            tools:ignore="LockedOrientationActivity" />
         <activity
             android:name=".presentation.detail.GoalDetailTestActivity"
-            android:exported="true">
+            android:exported="true"
+            android:screenOrientation="portrait"
+            tools:ignore="LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -34,7 +40,9 @@
         <activity
             android:name=".presentation.setting.GoalSettingActivity"
             android:exported="false"
-            android:windowSoftInputMode="adjustResize" />
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize"
+            tools:ignore="LockedOrientationActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/org/keepgoeat/App.kt
+++ b/app/src/main/java/org/keepgoeat/App.kt
@@ -1,6 +1,7 @@
 package org.keepgoeat
 
 import android.app.Application
+import androidx.appcompat.app.AppCompatDelegate
 import dagger.hilt.android.HiltAndroidApp
 import org.keepgoeat.util.KGEDebugTree
 import timber.log.Timber
@@ -10,5 +11,6 @@ class App : Application() {
     override fun onCreate() {
         super.onCreate()
         if (BuildConfig.DEBUG) Timber.plant(KGEDebugTree())
+        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #15

## Work Description ✏️
- 화면 회전 막기
- 다크모드 비활성화 처리

## To Reviewers 📢
- 매니페스트에 액티비티를 추가하실 때마다 아래 코드를 추가해주세용! 화면 회전으로 인한 크래시 발생을 방지하기 위함 입니다!
```xml
android:screenOrientation="portrait"
tools:ignore="LockedOrientationActivity"
```
