### PR TITLE
[feat] 목표 추가 api 연동

### DIFF
--- a/app/src/main/java/org/keepgoeat/data/datasource/remote/GoalDataSource.kt
+++ b/app/src/main/java/org/keepgoeat/data/datasource/remote/GoalDataSource.kt
@@ -1,6 +1,8 @@
 package org.keepgoeat.data.datasource.remote
 
 import org.keepgoeat.data.ApiResult
+import org.keepgoeat.data.model.request.RequestGoalContent
+import org.keepgoeat.data.model.response.ResponseGoalContent
 import org.keepgoeat.data.model.response.ResponseHome
 import org.keepgoeat.data.service.GoalService
 import org.keepgoeat.util.safeApiCall
@@ -11,4 +13,7 @@ class GoalDataSource @Inject constructor(
 ) {
     suspend fun fetchHomeEntireData(): ApiResult<ResponseHome?> =
         safeApiCall { goalService.fetchHomeEntireData() }
+
+    suspend fun uploadGoalContent(requestGoalContent: RequestGoalContent): ApiResult<ResponseGoalContent?> =
+        safeApiCall { goalService.uploadGoalContent(requestGoalContent) }
 }

--- a/app/src/main/java/org/keepgoeat/data/model/request/RequestGoalContent.kt
+++ b/app/src/main/java/org/keepgoeat/data/model/request/RequestGoalContent.kt
@@ -1,0 +1,9 @@
+package org.keepgoeat.data.model.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestGoalContent(
+    val goalContent: String,
+    val isMore: Boolean,
+)

--- a/app/src/main/java/org/keepgoeat/data/model/response/ResponseGoalContent.kt
+++ b/app/src/main/java/org/keepgoeat/data/model/response/ResponseGoalContent.kt
@@ -1,0 +1,18 @@
+package org.keepgoeat.data.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseGoalContent(
+    val status: Int,
+    val success: Boolean,
+    val message: String,
+    val data: ResponseGoalContentData,
+) {
+    @Serializable
+    data class ResponseGoalContentData(
+        @SerialName("goalId")
+        val id: Int,
+    )
+}

--- a/app/src/main/java/org/keepgoeat/data/repository/GoalRepositoryImpl.kt
+++ b/app/src/main/java/org/keepgoeat/data/repository/GoalRepositoryImpl.kt
@@ -2,6 +2,8 @@ package org.keepgoeat.data.repository
 
 import org.keepgoeat.data.ApiResult
 import org.keepgoeat.data.datasource.remote.GoalDataSource
+import org.keepgoeat.data.model.request.RequestGoalContent
+import org.keepgoeat.data.model.response.ResponseGoalContent
 import org.keepgoeat.data.model.response.ResponseHome
 import org.keepgoeat.domain.repository.GoalRepository
 import timber.log.Timber
@@ -22,6 +24,24 @@ class GoalRepositoryImpl @Inject constructor(
             }
             is ApiResult.GenericError -> {
                 Timber.d("(${result.code}): $(result.message}")
+                null
+            }
+        }
+    }
+
+    override suspend fun uploadGoalContent(title: String, isMore: Boolean): ResponseGoalContent.ResponseGoalContentData? {
+        val result = goalDataSource.uploadGoalContent(RequestGoalContent(title, isMore))
+
+        return when (result) {
+            is ApiResult.Success -> {
+                result.data?.data
+            }
+            is ApiResult.NetworkError -> {
+                Timber.d("Network Error")
+                null
+            }
+            is ApiResult.GenericError -> {
+                Timber.d("(${result.code}): ${result.message}")
                 null
             }
         }

--- a/app/src/main/java/org/keepgoeat/data/service/GoalService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/GoalService.kt
@@ -1,10 +1,17 @@
 package org.keepgoeat.data.service
 
+import org.keepgoeat.data.model.request.RequestGoalContent
+import org.keepgoeat.data.model.response.ResponseGoalContent
 import org.keepgoeat.data.model.response.ResponseHome
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 
 interface GoalService {
     @GET("home")
     suspend fun fetchHomeEntireData(): Response<ResponseHome>
+
+    @POST("goal")
+    suspend fun uploadGoalContent(@Body request: RequestGoalContent): Response<ResponseGoalContent>
 }

--- a/app/src/main/java/org/keepgoeat/domain/repository/GoalRepository.kt
+++ b/app/src/main/java/org/keepgoeat/domain/repository/GoalRepository.kt
@@ -1,7 +1,9 @@
 package org.keepgoeat.domain.repository
 
+import org.keepgoeat.data.model.response.ResponseGoalContent
 import org.keepgoeat.data.model.response.ResponseHome
 
 interface GoalRepository {
     suspend fun fetchHomeEntireData(): ResponseHome.HomeData?
+    suspend fun uploadGoalContent(title: String, isMore: Boolean): ResponseGoalContent.ResponseGoalContentData?
 }

--- a/app/src/main/java/org/keepgoeat/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/home/HomeActivity.kt
@@ -39,7 +39,7 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
     }
 
     private fun initLayout() {
-        goalAdapter = HomeMyGoalAdapter(::changeGoalItemBtnColor, ::moveToDetail)
+        goalAdapter = HomeMyGoalAdapter(::changeGoalItemBtnColor, ::moveToDetail, ::showMakeGoalDialog)
         binding.rvMyGoals.apply {
             itemAnimator = null
             adapter = goalAdapter

--- a/app/src/main/java/org/keepgoeat/presentation/home/HomeBottomDialogFragment.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/home/HomeBottomDialogFragment.kt
@@ -19,11 +19,9 @@ class HomeBottomDialogFragment :
     private fun addListeners() {
         binding.layoutHomeBottomMore.setOnClickListener {
             moveToSetting(EatingType.MORE)
-            dismiss()
         }
         binding.layoutHomeBottomLess.setOnClickListener {
             moveToSetting(EatingType.LESS)
-            dismiss()
         }
     }
 
@@ -31,5 +29,6 @@ class HomeBottomDialogFragment :
         val intent = Intent(requireActivity(), GoalSettingActivity::class.java)
         intent.putExtra(GoalSettingActivity.ARG_EATING_TYPE, eatingType.name)
         startActivity(intent)
+        dismiss()
     }
 }

--- a/app/src/main/java/org/keepgoeat/presentation/home/HomeMyGoalAdapter.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/home/HomeMyGoalAdapter.kt
@@ -17,7 +17,8 @@ import org.keepgoeat.util.setVisibility
 
 class HomeMyGoalAdapter(
     private val changeBtnColor: (HomeGoal) -> Unit,
-    private val moveToDetail: (EatingType, Int) -> Unit
+    private val moveToDetail: (EatingType, Int) -> Unit,
+    private val showMakeGoalDialog: () -> Unit,
 ) : ListAdapter<HomeGoal, RecyclerView.ViewHolder>(
     ItemDiffCallback<HomeGoal>(
         onContentsTheSame = { old, new -> old == new },
@@ -27,14 +28,14 @@ class HomeMyGoalAdapter(
     private lateinit var inflater: LayoutInflater
 
     class MyGoalViewHolder(
-        private val binding: ItemHomeGoalBinding
+        private val binding: ItemHomeGoalBinding,
     ) : RecyclerView.ViewHolder(binding.root) {
         var layout = binding
         fun bind(
             myGoal: HomeGoal,
             eatingType: EatingType,
             changeBtnColor: (HomeGoal) -> Unit,
-            moveToDetail: (EatingType, Int) -> Unit
+            moveToDetail: (EatingType, Int) -> Unit,
         ) {
             val btnType: HomeBtnType = if (eatingType == EatingType.MORE) { // 더 먹기인 경우
                 if (myGoal.isAchieved) {
@@ -65,10 +66,10 @@ class HomeMyGoalAdapter(
     }
 
     class AddGoalViewHolder(
-        private val binding: ItemAddGoalBinding
+        private val binding: ItemAddGoalBinding,
     ) : RecyclerView.ViewHolder(binding.root) {
         var layout = binding
-        fun bind(goalCount: Int) {
+        fun bind(goalCount: Int, showMakeGoalDialog: () -> Unit) {
             when (goalCount) {
                 0 -> binding.layoutGoalInfo.visibility = View.GONE
                 1 -> binding.tvAddMoreGoal.setText(R.string.home_two_more_goal)
@@ -77,6 +78,10 @@ class HomeMyGoalAdapter(
                     binding.tvAddMoreGoal.setText(R.string.home_no_more_goal)
                     binding.btnMakeGoal.setVisibility(false)
                 }
+            }
+
+            binding.root.setOnClickListener {
+                showMakeGoalDialog()
             }
         }
     }
@@ -107,7 +112,7 @@ class HomeMyGoalAdapter(
                 }
             }
             // TODO 서버통신 데이터클래스로 변경하면 size 정보 받아온걸로 바꾸기
-            is AddGoalViewHolder -> holder.bind(currentList.size - 1)
+            is AddGoalViewHolder -> holder.bind(currentList.size - 1, showMakeGoalDialog)
         }
     }
 

--- a/app/src/main/java/org/keepgoeat/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/home/HomeViewModel.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    private val goalRepository: GoalRepository
+    private val goalRepository: GoalRepository,
 ) : ViewModel() {
     private var _goalList = MutableLiveData<MutableList<HomeGoal>>()
     val goalList: LiveData<MutableList<HomeGoal>> get() = _goalList

--- a/app/src/main/java/org/keepgoeat/presentation/setting/GoalSettingActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/setting/GoalSettingActivity.kt
@@ -1,10 +1,12 @@
 package org.keepgoeat.presentation.setting
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.keepgoeat.R
 import org.keepgoeat.databinding.ActivityGoalSettingBinding
+import org.keepgoeat.presentation.home.HomeActivity
 import org.keepgoeat.presentation.type.EatingType
 import org.keepgoeat.util.UiState
 import org.keepgoeat.util.binding.BindingActivity
@@ -33,7 +35,7 @@ class GoalSettingActivity : BindingActivity<ActivityGoalSettingBinding>(R.layout
         viewModel.uploadState.observe(this) { state ->
             when (state) {
                 is UiState.Success -> {
-                    finish()
+                    moveToHome()
                 }
                 else -> {}
             }
@@ -48,6 +50,12 @@ class GoalSettingActivity : BindingActivity<ActivityGoalSettingBinding>(R.layout
         binding.ivBack.setOnClickListener {
             finish()
         }
+    }
+
+    private fun moveToHome() {
+        val intent = Intent(this, HomeActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        startActivity(intent)
     }
 
     companion object {

--- a/app/src/main/java/org/keepgoeat/presentation/setting/GoalSettingActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/setting/GoalSettingActivity.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.keepgoeat.R
 import org.keepgoeat.databinding.ActivityGoalSettingBinding
 import org.keepgoeat.presentation.type.EatingType
+import org.keepgoeat.util.UiState
 import org.keepgoeat.util.binding.BindingActivity
 import org.keepgoeat.util.extension.showKeyboard
 import org.keepgoeat.util.safeValueOf
@@ -25,6 +26,18 @@ class GoalSettingActivity : BindingActivity<ActivityGoalSettingBinding>(R.layout
         }
 
         addListeners()
+        addObservers()
+    }
+
+    private fun addObservers() {
+        viewModel.uploadState.observe(this) { state ->
+            when (state) {
+                is UiState.Success -> {
+                    finish()
+                }
+                else -> {}
+            }
+        }
     }
 
     private fun addListeners() {

--- a/app/src/main/res/layout/activity_goal_setting.xml
+++ b/app/src/main/res/layout/activity_goal_setting.xml
@@ -136,6 +136,7 @@
             android:layout_marginBottom="42dp"
             android:backgroundTint="@color/selector_complete_button_color"
             android:enabled="@{viewModel.isValidTitle}"
+            android:onClick="@{() -> viewModel.uploadGoal()}"
             android:text="@string/complete"
             android:textColor="@color/selector_complete_button_text_color"
             app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
## Related issue 🛠
- closed #73

## Work Description ✏️
- 목표 추가 api 연동
- 홈에서 목표 추가 푸터 클릭 시 목표 추가 다이얼로그 띄우기 구현
- 목표 추가 완료 후 홈으로 복귀 및 목표 조회 api 호출 구현
