### PR TITLE
 [feat] 응원 메세지 줄바꿈 적용되도록 개행문자를 "\\n" -> "\n" 처리

### DIFF
--- a/app/src/main/java/org/keepgoeat/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/home/HomeViewModel.kt
@@ -58,7 +58,7 @@ class HomeViewModel @Inject constructor(
     private fun fetchGoalList() {
         viewModelScope.launch {
             goalRepository.fetchHomeEntireData()?.let { homeData ->
-                _cheeringMessage.value = homeData.cheeringMessage
+                _cheeringMessage.value = homeData.cheeringMessage.replace("\\n", "\n")
                 _achievedState.value = false
                 _goalList.value = homeData.toHomeGoal().toMutableList()
                 _goalCount.value = homeData.goals.size


### PR DESCRIPTION
## Related issue 🛠
- closed #127

## Work Description ✏️
- 응원 메세지 줄바꿈 적용되도록 개행문자를 "\\n" -> "\n" 처리
- 해당 처리를 해주지 않으면 홈뷰에서 개행문자 \n이 그대로 보이는 버그가 있음

## Screenshot 📸
<img src="https://user-images.githubusercontent.com/48701368/212359433-c763ca0a-5c82-4116-aed6-515702693926.png" width="360"/>
