### PR TITLE
네이버 로그인 api 연동

### DIFF
--- a/app/src/main/java/org/keepgoeat/data/service/AuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/AuthService.kt
@@ -5,12 +5,13 @@ import org.keepgoeat.data.model.response.ResponseAuth
 import org.keepgoeat.data.model.response.ResponseRefresh
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
 
 interface AuthService {
     @POST("auth")
     suspend fun login(@Body request: RequestAuth): Response<ResponseAuth>
 
-    @POST("auth/refresh")
+    @GET("auth/refresh")
     suspend fun refresh(): Response<ResponseRefresh>
 }

--- a/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
@@ -4,8 +4,13 @@ import android.content.Context
 import com.navercorp.nid.NaverIdLoginSDK
 import com.navercorp.nid.oauth.OAuthLoginCallback
 import dagger.hilt.android.qualifiers.ActivityContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.keepgoeat.BuildConfig
 import org.keepgoeat.data.datasource.local.KGEDataSource
+import org.keepgoeat.data.model.request.RequestAuth
 import org.keepgoeat.domain.repository.AuthRepository
 import timber.log.Timber
 import javax.inject.Inject
@@ -25,7 +30,24 @@ class NaverAuthService @Inject constructor(
     fun loginNaver(loginListener: ((Boolean, Boolean) -> Unit)) {
         val oauthLoginCallback = object : OAuthLoginCallback {
             override fun onSuccess() {
-                // TODO: 네이버 로그인 성공 시 로직 처리
+                CoroutineScope(Dispatchers.Main).launch {
+                    val result = withContext(Dispatchers.IO) {
+                        NaverIdLoginSDK.getAccessToken()?.let { accessToken ->
+                            RequestAuth(
+                                accessToken, PLATFORM_NAVER
+                            )
+                        }?.let {
+                            authRepository.login(
+                                it
+                            )
+                        }
+                    }
+                    Timber.d(NaverIdLoginSDK.getAccessToken())
+                    loginListener(
+                        result?.type == SIGN_UP,
+                        localStorage.isClickedOnboardingButton
+                    )
+                }
             }
 
             override fun onFailure(httpStatus: Int, message: String) {
@@ -44,5 +66,7 @@ class NaverAuthService @Inject constructor(
 
     companion object {
         private const val CLIENT_NAME = "킵고잇"
+        private const val PLATFORM_NAVER = "NAVER"
+        private const val SIGN_UP = "signup"
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #146 

## Work Description ✏️
- 토큰 재발급 api HTTP 메소드를 GET으로 변경
- 네이버 로그인 성공시 로직 처리
