### PR TITLE
[feat] 로그아웃 및 회원 탈퇴 구현

### DIFF
--- a/app/src/main/java/org/keepgoeat/data/datasource/local/KGEDataSource.kt
+++ b/app/src/main/java/org/keepgoeat/data/datasource/local/KGEDataSource.kt
@@ -7,6 +7,8 @@ import androidx.databinding.ktx.BuildConfig
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import dagger.hilt.android.qualifiers.ApplicationContext
+import org.keepgoeat.presentation.type.SocialLoginType
+import org.keepgoeat.util.safeValueOf
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -49,6 +51,13 @@ class KGEDataSource @Inject constructor(@ApplicationContext context: Context) {
         set(value) = dataStore.edit { putBoolean(IS_CLICKED_ONBOARDING_BUTTON, value) }
         get() = dataStore.getBoolean(IS_CLICKED_ONBOARDING_BUTTON, false)
 
+    var loginPlatform: SocialLoginType
+        set(value) = dataStore.edit { putString(LOGIN_PLATFORM, value.name) }
+        get() = safeValueOf<SocialLoginType>(dataStore.getString(
+            LOGIN_PLATFORM,
+            ""
+        )) ?: SocialLoginType.NONE
+
     fun clear() {
         dataStore.edit {
             clear()
@@ -61,5 +70,6 @@ class KGEDataSource @Inject constructor(@ApplicationContext context: Context) {
         const val IS_LOGIN = "isLogin"
         const val REFRESH_TOKEN = "refreshToken"
         const val IS_CLICKED_ONBOARDING_BUTTON = "isClickedOnboardingButton"
+        const val LOGIN_PLATFORM = "loginPlatform"
     }
 }

--- a/app/src/main/java/org/keepgoeat/data/datasource/local/KGEDataSource.kt
+++ b/app/src/main/java/org/keepgoeat/data/datasource/local/KGEDataSource.kt
@@ -53,10 +53,8 @@ class KGEDataSource @Inject constructor(@ApplicationContext context: Context) {
 
     var loginPlatform: SocialLoginType
         set(value) = dataStore.edit { putString(LOGIN_PLATFORM, value.name) }
-        get() = safeValueOf<SocialLoginType>(dataStore.getString(
-            LOGIN_PLATFORM,
-            ""
-        )) ?: SocialLoginType.NONE
+        get() = safeValueOf<SocialLoginType>(dataStore.getString(LOGIN_PLATFORM, ""))
+            ?: SocialLoginType.NONE
 
     fun clear() {
         dataStore.edit {

--- a/app/src/main/java/org/keepgoeat/data/datasource/remote/AuthDataSource.kt
+++ b/app/src/main/java/org/keepgoeat/data/datasource/remote/AuthDataSource.kt
@@ -3,13 +3,16 @@ package org.keepgoeat.data.datasource.remote
 import org.keepgoeat.data.model.request.RequestAuth
 import org.keepgoeat.data.model.response.ResponseAuth
 import org.keepgoeat.data.model.response.ResponseRefresh
+import org.keepgoeat.data.model.response.ResponseWithdraw
 import org.keepgoeat.data.service.AuthService
 import javax.inject.Inject
 
 class AuthDataSource @Inject constructor(
-    private val authService: AuthService
+    private val authService: AuthService,
 ) {
     suspend fun login(requestAuth: RequestAuth): ResponseAuth = authService.login(requestAuth)
 
     suspend fun refresh(): ResponseRefresh = authService.refresh()
+
+    suspend fun deleteAccount(): ResponseWithdraw = authService.deleteAccount()
 }

--- a/app/src/main/java/org/keepgoeat/data/model/response/ResponseWithdraw.kt
+++ b/app/src/main/java/org/keepgoeat/data/model/response/ResponseWithdraw.kt
@@ -1,0 +1,10 @@
+package org.keepgoeat.data.model.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseWithdraw(
+    val message: String,
+    val status: Int,
+    val success: Boolean,
+)

--- a/app/src/main/java/org/keepgoeat/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/org/keepgoeat/data/repository/AuthRepositoryImpl.kt
@@ -39,9 +39,8 @@ class AuthRepositoryImpl @Inject constructor(
             Timber.e(it.message)
         }
 
-
-    // TODO 코드 정리 필요
-    override suspend fun refresh(): Result<ResponseRefresh.ResponseToken?> = runCatching {
-        authDataSource.refresh().data
-    }
+    override suspend fun refresh(): Result<ResponseRefresh.ResponseToken?> =
+        runCatching {
+            authDataSource.refresh().data
+        }
 }

--- a/app/src/main/java/org/keepgoeat/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/org/keepgoeat/data/repository/AuthRepositoryImpl.kt
@@ -14,7 +14,7 @@ class AuthRepositoryImpl @Inject constructor(
     private val localStorage: KGEDataSource
 ) : AuthRepository {
     override suspend fun login(requestAuth: RequestAuth): Result<ResponseAuth.ResponseAuthData?> =
-        kotlin.runCatching {
+        runCatching {
             authDataSource.login(requestAuth).data
         }.onSuccess {
             with(localStorage) {

--- a/app/src/main/java/org/keepgoeat/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/org/keepgoeat/data/repository/AuthRepositoryImpl.kt
@@ -5,13 +5,14 @@ import org.keepgoeat.data.datasource.remote.AuthDataSource
 import org.keepgoeat.data.model.request.RequestAuth
 import org.keepgoeat.data.model.response.ResponseAuth
 import org.keepgoeat.data.model.response.ResponseRefresh
+import org.keepgoeat.data.model.response.ResponseWithdraw
 import org.keepgoeat.domain.repository.AuthRepository
 import timber.log.Timber
 import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
     private val authDataSource: AuthDataSource,
-    private val localStorage: KGEDataSource
+    private val localStorage: KGEDataSource,
 ) : AuthRepository {
     override suspend fun login(requestAuth: RequestAuth): Result<ResponseAuth.ResponseAuthData?> =
         runCatching {
@@ -28,6 +29,18 @@ class AuthRepositoryImpl @Inject constructor(
             Timber.e(it.message)
         }
 
+    override suspend fun deleteAccount(): Result<ResponseWithdraw> =
+        runCatching {
+            authDataSource.deleteAccount()
+        }.onSuccess {
+            Timber.d("회원 탈퇴 성공")
+            localStorage.clear()
+        }.onFailure {
+            Timber.e(it.message)
+        }
+
+
+    // TODO 코드 정리 필요
     override suspend fun refresh(): Result<ResponseRefresh.ResponseToken?> = runCatching {
         authDataSource.refresh().data
     }

--- a/app/src/main/java/org/keepgoeat/data/service/AuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/AuthService.kt
@@ -3,6 +3,7 @@ package org.keepgoeat.data.service
 import org.keepgoeat.data.model.request.RequestAuth
 import org.keepgoeat.data.model.response.ResponseAuth
 import org.keepgoeat.data.model.response.ResponseRefresh
+import org.keepgoeat.data.model.response.ResponseWithdraw
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -13,4 +14,7 @@ interface AuthService {
 
     @GET("auth/refresh")
     suspend fun refresh(): ResponseRefresh
+
+    @GET("auth/withdraw")
+    suspend fun deleteAccount(): ResponseWithdraw
 }

--- a/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
@@ -4,13 +4,6 @@ import android.content.Context
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.user.UserApiClient
 import dagger.hilt.android.qualifiers.ActivityContext
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import org.keepgoeat.data.datasource.local.KGEDataSource
-import org.keepgoeat.data.model.request.RequestAuth
-import org.keepgoeat.domain.repository.AuthRepository
 import org.keepgoeat.presentation.type.SocialLoginType
 import timber.log.Timber
 import javax.inject.Inject
@@ -18,13 +11,11 @@ import javax.inject.Inject
 class KakaoAuthService @Inject constructor(
     @ActivityContext private val context: Context,
     private val client: UserApiClient,
-    private val authRepository: AuthRepository,
-    private val localStorage: KGEDataSource,
 ) {
     private val isKakaoTalkLoginAvailable: Boolean
         get() = client.isKakaoTalkLoginAvailable(context)
 
-    fun loginKakao(loginListener: ((Boolean, Boolean) -> Unit)) {
+    fun loginKakao(loginListener: ((SocialLoginType, String) -> Unit)) {
         val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
             if (error != null) handleLoginError(error)
             else if (token != null) handleLoginSuccess(token, loginListener)
@@ -41,22 +32,11 @@ class KakaoAuthService @Inject constructor(
 
     private fun handleLoginSuccess(
         oAuthToken: OAuthToken,
-        loginListener: ((Boolean, Boolean) -> Unit),
+        loginListener: ((SocialLoginType, String) -> Unit),
     ) {
-        client.me { user, _ ->
-            CoroutineScope(Dispatchers.Main).launch {
-                val result = withContext(Dispatchers.IO) {
-                    authRepository.login(RequestAuth(oAuthToken.accessToken, PLATFORM_KAKAO))
-                }
-                Timber.d(oAuthToken.accessToken)
-                localStorage.loginPlatform = SocialLoginType.KAKAO // TODO 리팩토링 필요
-                result?.let {
-                    loginListener(
-                        result.getOrThrow()?.type == SIGN_UP,
-                        localStorage.isClickedOnboardingButton
-                    )
-                }
-            }
+        client.me { _, _ ->
+            Timber.d(oAuthToken.accessToken)
+            loginListener(SocialLoginType.KAKAO, oAuthToken.accessToken)
         }
     }
 
@@ -80,10 +60,5 @@ class KakaoAuthService @Inject constructor(
                 Timber.e("연결 끊기 실패($error)")
             }
         }
-    }
-
-    companion object {
-        private const val PLATFORM_KAKAO = "KAKAO"
-        private const val SIGN_UP = "signup"
     }
 }

--- a/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.withContext
 import org.keepgoeat.data.datasource.local.KGEDataSource
 import org.keepgoeat.data.model.request.RequestAuth
 import org.keepgoeat.domain.repository.AuthRepository
+import org.keepgoeat.presentation.type.SocialLoginType
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -48,6 +49,7 @@ class KakaoAuthService @Inject constructor(
                     authRepository.login(RequestAuth(oAuthToken.accessToken, PLATFORM_KAKAO))
                 }
                 Timber.d(oAuthToken.accessToken)
+                localStorage.loginPlatform = SocialLoginType.KAKAO // TODO 리팩토링 필요
                 result?.let {
                     loginListener(
                         result.getOrThrow()?.type == SIGN_UP,

--- a/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
@@ -58,8 +58,26 @@ class KakaoAuthService @Inject constructor(
         }
     }
 
-    fun logout() {
-        client.logout(Timber::e)
+    fun logoutKakao() {
+        client.logout { error ->
+            if (error == null) {
+                Timber.i("로그아웃 성공. SDK에서 토큰 삭제됨")
+                // TODO 로컬 데이터 삭제
+            } else {
+                Timber.e("로그아웃 실패. SDK에서 토큰 삭제됨($error)")
+            }
+        }
+    }
+
+    fun unlinkKakao() {
+        client.unlink { error ->
+            if (error == null) {
+                Timber.d("연결 끊기 성공. SDK에서 토큰 삭제 됨")
+                // TODO 탈퇴 api 호출 및 로컬 데이터 삭제
+            } else {
+                Timber.e("연결 끊기 실패($error)")
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
@@ -71,12 +71,12 @@ class KakaoAuthService @Inject constructor(
         }
     }
 
-    fun unlinkKakao() {
+    // TODO 함수명 변경
+    fun unlinkKakao(deleteAccountListener: (() -> Unit)) {
         client.unlink { error ->
             if (error == null) {
                 Timber.d("연결 끊기 성공. SDK에서 토큰 삭제 됨")
-                // TODO 탈퇴 api 호출
-                localStorage.clear()
+                deleteAccountListener()
             } else {
                 Timber.e("연결 끊기 실패($error)")
             }

--- a/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
@@ -71,8 +71,7 @@ class KakaoAuthService @Inject constructor(
         }
     }
 
-    // TODO 함수명 변경
-    fun unlinkKakao(deleteAccountListener: (() -> Unit)) {
+    fun deleteAccountKakao(deleteAccountListener: (() -> Unit)) {
         client.unlink { error ->
             if (error == null) {
                 Timber.d("연결 끊기 성공. SDK에서 토큰 삭제 됨")

--- a/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
@@ -62,7 +62,7 @@ class KakaoAuthService @Inject constructor(
         client.logout { error ->
             if (error == null) {
                 Timber.i("로그아웃 성공. SDK에서 토큰 삭제됨")
-                // TODO 로컬 데이터 삭제
+                localStorage.clear()
             } else {
                 Timber.e("로그아웃 실패. SDK에서 토큰 삭제됨($error)")
             }
@@ -73,7 +73,8 @@ class KakaoAuthService @Inject constructor(
         client.unlink { error ->
             if (error == null) {
                 Timber.d("연결 끊기 성공. SDK에서 토큰 삭제 됨")
-                // TODO 탈퇴 api 호출 및 로컬 데이터 삭제
+                // TODO 탈퇴 api 호출
+                localStorage.clear()
             } else {
                 Timber.e("연결 끊기 실패($error)")
             }

--- a/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
@@ -60,11 +60,11 @@ class KakaoAuthService @Inject constructor(
         }
     }
 
-    fun logoutKakao() {
+    fun logoutKakao(logoutListener: (() -> Unit)) {
         client.logout { error ->
             if (error == null) {
                 Timber.i("로그아웃 성공. SDK에서 토큰 삭제됨")
-                localStorage.clear()
+                logoutListener()
             } else {
                 Timber.e("로그아웃 실패. SDK에서 토큰 삭제됨($error)")
             }

--- a/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
@@ -58,13 +58,14 @@ class NaverAuthService @Inject constructor(
 
     fun logoutNaver() {
         NaverIdLoginSDK.logout()
-        // TODO 로컬 데이터 삭제
+        localStorage.clear()
     }
 
     fun unlinkNaver() {
         NidOAuthLogin().callDeleteTokenApi(context, object : OAuthLoginCallback {
             override fun onSuccess() {
-                // TODO 탈퇴 api 호출 및 로컬 데이터 삭제
+                // TODO 탈퇴 api 호출
+                localStorage.clear()
             }
             override fun onFailure(httpStatus: Int, message: String) {
                 Timber.d("errorCode: ${NaverIdLoginSDK.getLastErrorCode().code}")

--- a/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
@@ -60,9 +60,9 @@ class NaverAuthService @Inject constructor(
         )
     }
 
-    fun logoutNaver() {
+    fun logoutNaver(logoutListener: (() -> Unit)) {
         NaverIdLoginSDK.logout()
-        localStorage.clear()
+        logoutListener()
     }
 
     // TODO 함수명 변경

--- a/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
@@ -13,6 +13,7 @@ import org.keepgoeat.BuildConfig
 import org.keepgoeat.data.datasource.local.KGEDataSource
 import org.keepgoeat.data.model.request.RequestAuth
 import org.keepgoeat.domain.repository.AuthRepository
+import org.keepgoeat.presentation.type.SocialLoginType
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -39,9 +40,12 @@ class NaverAuthService @Inject constructor(
                         )
                     }
                     Timber.d(accessToken)
-                    loginListener(result.getOrThrow()?.type == SIGN_UP, localStorage.isClickedOnboardingButton)
+                    localStorage.loginPlatform = SocialLoginType.NAVER // TODO 리팩토링 필요
+                    loginListener(result.getOrThrow()?.type == SIGN_UP,
+                        localStorage.isClickedOnboardingButton)
                 }
             }
+
             override fun onFailure(httpStatus: Int, message: String) {
                 Timber.i(NaverIdLoginSDK.getLastErrorCode().code)
                 Timber.i(NaverIdLoginSDK.getLastErrorDescription())
@@ -67,10 +71,12 @@ class NaverAuthService @Inject constructor(
                 // TODO 탈퇴 api 호출
                 localStorage.clear()
             }
+
             override fun onFailure(httpStatus: Int, message: String) {
                 Timber.d("errorCode: ${NaverIdLoginSDK.getLastErrorCode().code}")
                 Timber.d("errorDesc: ${NaverIdLoginSDK.getLastErrorDescription()}")
             }
+
             override fun onError(errorCode: Int, message: String) {
                 onFailure(errorCode, message)
             }

--- a/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
@@ -65,11 +65,12 @@ class NaverAuthService @Inject constructor(
         localStorage.clear()
     }
 
-    fun unlinkNaver() {
+    // TODO 함수명 변경
+    fun unlinkNaver(deleteAccountListener: (() -> Unit)) {
         NidOAuthLogin().callDeleteTokenApi(context, object : OAuthLoginCallback {
             override fun onSuccess() {
-                // TODO 탈퇴 api 호출
-                localStorage.clear()
+                Timber.d("연결 끊기 성공. SDK에서 토큰 삭제 됨")
+                deleteAccountListener()
             }
 
             override fun onFailure(httpStatus: Int, message: String) {

--- a/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
@@ -65,8 +65,7 @@ class NaverAuthService @Inject constructor(
         logoutListener()
     }
 
-    // TODO 함수명 변경
-    fun unlinkNaver(deleteAccountListener: (() -> Unit)) {
+    fun deleteAccountNaver(deleteAccountListener: (() -> Unit)) {
         NidOAuthLogin().callDeleteTokenApi(context, object : OAuthLoginCallback {
             override fun onSuccess() {
                 Timber.d("연결 끊기 성공. SDK에서 토큰 삭제 됨")

--- a/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
@@ -2,6 +2,7 @@ package org.keepgoeat.data.service
 
 import android.content.Context
 import com.navercorp.nid.NaverIdLoginSDK
+import com.navercorp.nid.oauth.NidOAuthLogin
 import com.navercorp.nid.oauth.OAuthLoginCallback
 import dagger.hilt.android.qualifiers.ActivityContext
 import kotlinx.coroutines.CoroutineScope
@@ -53,6 +54,26 @@ class NaverAuthService @Inject constructor(
         NaverIdLoginSDK.authenticate(
             context, oauthLoginCallback
         )
+    }
+
+    fun logoutNaver() {
+        NaverIdLoginSDK.logout()
+        // TODO 로컬 데이터 삭제
+    }
+
+    fun unlinkNaver() {
+        NidOAuthLogin().callDeleteTokenApi(context, object : OAuthLoginCallback {
+            override fun onSuccess() {
+                // TODO 탈퇴 api 호출 및 로컬 데이터 삭제
+            }
+            override fun onFailure(httpStatus: Int, message: String) {
+                Timber.d("errorCode: ${NaverIdLoginSDK.getLastErrorCode().code}")
+                Timber.d("errorDesc: ${NaverIdLoginSDK.getLastErrorDescription()}")
+            }
+            override fun onError(errorCode: Int, message: String) {
+                onFailure(errorCode, message)
+            }
+        })
     }
 
     companion object {

--- a/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
@@ -48,21 +48,24 @@ class NaverAuthService @Inject constructor(
     }
 
     fun deleteAccountNaver(deleteAccountListener: (() -> Unit)) {
-        NidOAuthLogin().callDeleteTokenApi(context, object : OAuthLoginCallback {
-            override fun onSuccess() {
-                Timber.d("연결 끊기 성공. SDK에서 토큰 삭제 됨")
-                deleteAccountListener()
-            }
+        NidOAuthLogin().callDeleteTokenApi(
+            context,
+            object : OAuthLoginCallback {
+                override fun onSuccess() {
+                    Timber.d("연결 끊기 성공. SDK에서 토큰 삭제 됨")
+                    deleteAccountListener()
+                }
 
-            override fun onFailure(httpStatus: Int, message: String) {
-                Timber.d("errorCode: ${NaverIdLoginSDK.getLastErrorCode().code}")
-                Timber.d("errorDesc: ${NaverIdLoginSDK.getLastErrorDescription()}")
-            }
+                override fun onFailure(httpStatus: Int, message: String) {
+                    Timber.d("errorCode: ${NaverIdLoginSDK.getLastErrorCode().code}")
+                    Timber.d("errorDesc: ${NaverIdLoginSDK.getLastErrorDescription()}")
+                }
 
-            override fun onError(errorCode: Int, message: String) {
-                onFailure(errorCode, message)
+                override fun onError(errorCode: Int, message: String) {
+                    onFailure(errorCode, message)
+                }
             }
-        })
+        )
     }
 
     companion object {

--- a/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
@@ -5,22 +5,13 @@ import com.navercorp.nid.NaverIdLoginSDK
 import com.navercorp.nid.oauth.NidOAuthLogin
 import com.navercorp.nid.oauth.OAuthLoginCallback
 import dagger.hilt.android.qualifiers.ActivityContext
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.keepgoeat.BuildConfig
-import org.keepgoeat.data.datasource.local.KGEDataSource
-import org.keepgoeat.data.model.request.RequestAuth
-import org.keepgoeat.domain.repository.AuthRepository
 import org.keepgoeat.presentation.type.SocialLoginType
 import timber.log.Timber
 import javax.inject.Inject
 
 class NaverAuthService @Inject constructor(
     @ActivityContext private val context: Context,
-    private val authRepository: AuthRepository,
-    private val localStorage: KGEDataSource,
 ) {
     init {
         NaverIdLoginSDK.initialize(
@@ -29,21 +20,12 @@ class NaverAuthService @Inject constructor(
         )
     }
 
-    fun loginNaver(loginListener: ((Boolean, Boolean) -> Unit)) {
+    fun loginNaver(loginListener: ((SocialLoginType, String) -> Unit)) {
         val oauthLoginCallback = object : OAuthLoginCallback {
             override fun onSuccess() {
                 val accessToken = requireNotNull(NaverIdLoginSDK.getAccessToken())
-                CoroutineScope(Dispatchers.Main).launch {
-                    val result = withContext(Dispatchers.IO) {
-                        authRepository.login(
-                            RequestAuth(accessToken, PLATFORM_NAVER)
-                        )
-                    }
-                    Timber.d(accessToken)
-                    localStorage.loginPlatform = SocialLoginType.NAVER // TODO 리팩토링 필요
-                    loginListener(result.getOrThrow()?.type == SIGN_UP,
-                        localStorage.isClickedOnboardingButton)
-                }
+                Timber.d(accessToken)
+                loginListener(SocialLoginType.NAVER, accessToken)
             }
 
             override fun onFailure(httpStatus: Int, message: String) {
@@ -85,7 +67,5 @@ class NaverAuthService @Inject constructor(
 
     companion object {
         private const val CLIENT_NAME = "킵고잇"
-        private const val PLATFORM_NAVER = "NAVER"
-        private const val SIGN_UP = "signup"
     }
 }

--- a/app/src/main/java/org/keepgoeat/di/SignModule.kt
+++ b/app/src/main/java/org/keepgoeat/di/SignModule.kt
@@ -8,10 +8,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityComponent
 import dagger.hilt.android.qualifiers.ActivityContext
 import dagger.hilt.android.scopes.ActivityScoped
-import org.keepgoeat.data.datasource.local.KGEDataSource
 import org.keepgoeat.data.service.KakaoAuthService
 import org.keepgoeat.data.service.NaverAuthService
-import org.keepgoeat.domain.repository.AuthRepository
 
 @Module
 @InstallIn(ActivityComponent::class)
@@ -24,14 +22,10 @@ object SignModule {
     fun provideKakaoSignService(
         @ActivityContext context: Context,
         client: UserApiClient,
-        authRepository: AuthRepository,
-        localStorage: KGEDataSource,
-    ) = KakaoAuthService(context, client, authRepository, localStorage)
+    ) = KakaoAuthService(context, client)
 
     @Provides
     fun provideNaverSignService(
         @ActivityContext context: Context,
-        authRepository: AuthRepository,
-        localStorage: KGEDataSource,
-    ) = NaverAuthService(context, authRepository, localStorage)
+    ) = NaverAuthService(context)
 }

--- a/app/src/main/java/org/keepgoeat/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/org/keepgoeat/domain/repository/AuthRepository.kt
@@ -3,8 +3,10 @@ package org.keepgoeat.domain.repository
 import org.keepgoeat.data.model.request.RequestAuth
 import org.keepgoeat.data.model.response.ResponseAuth
 import org.keepgoeat.data.model.response.ResponseRefresh
+import org.keepgoeat.data.model.response.ResponseWithdraw
 
 interface AuthRepository {
     suspend fun login(requestAuth: RequestAuth): Result<ResponseAuth.ResponseAuthData?>
     suspend fun refresh(): Result<ResponseRefresh.ResponseToken?>
+    suspend fun deleteAccount(): Result<ResponseWithdraw>
 }

--- a/app/src/main/java/org/keepgoeat/presentation/my/MyActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/my/MyActivity.kt
@@ -11,15 +11,24 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.keepgoeat.R
+import org.keepgoeat.data.service.KakaoAuthService
+import org.keepgoeat.data.service.NaverAuthService
 import org.keepgoeat.databinding.ActivityMyBinding
 import org.keepgoeat.presentation.home.HomeActivity
 import org.keepgoeat.presentation.type.EatingType
+import org.keepgoeat.presentation.type.SocialLoginType
 import org.keepgoeat.presentation.type.SortType
 import org.keepgoeat.util.UiState
 import org.keepgoeat.util.binding.BindingActivity
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MyActivity : BindingActivity<ActivityMyBinding>(R.layout.activity_my) {
+    @Inject
+    lateinit var kakaoSignService: KakaoAuthService
+
+    @Inject
+    lateinit var naverSignService: NaverAuthService
     private val viewModel: MyViewModel by viewModels()
     private val goalAdapter = MyGoalAdapter()
     private val headerAdapter = MyHeaderAdapter(::getFilteredGoalWithEatingType)
@@ -65,10 +74,18 @@ class MyActivity : BindingActivity<ActivityMyBinding>(R.layout.activity_my) {
             moveToPrevious()
         }
         binding.tvLogout.setOnClickListener {
-            // TODO 로그아웃 로직 연결
+            when (viewModel.loginPlatForm) {
+                SocialLoginType.NAVER -> naverSignService.logoutNaver()
+                SocialLoginType.KAKAO -> kakaoSignService.logoutKakao()
+                else -> {}
+            }
         }
         binding.tvDeleteAccount.setOnClickListener {
-            // TODO 회원탈퇴 로직 연결
+            when (viewModel.loginPlatForm) {
+                SocialLoginType.NAVER -> naverSignService.unlinkNaver() // TODO 회원 탈퇴 성공 시 api 호출
+                SocialLoginType.KAKAO -> kakaoSignService.unlinkKakao()
+                else -> {}
+            }
         }
     }
 

--- a/app/src/main/java/org/keepgoeat/presentation/my/MyActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/my/MyActivity.kt
@@ -15,6 +15,7 @@ import org.keepgoeat.data.service.KakaoAuthService
 import org.keepgoeat.data.service.NaverAuthService
 import org.keepgoeat.databinding.ActivityMyBinding
 import org.keepgoeat.presentation.home.HomeActivity
+import org.keepgoeat.presentation.sign.SignActivity
 import org.keepgoeat.presentation.type.EatingType
 import org.keepgoeat.presentation.type.SocialLoginType
 import org.keepgoeat.presentation.type.SortType
@@ -82,8 +83,8 @@ class MyActivity : BindingActivity<ActivityMyBinding>(R.layout.activity_my) {
         }
         binding.tvDeleteAccount.setOnClickListener {
             when (viewModel.loginPlatForm) {
-                SocialLoginType.NAVER -> naverSignService.unlinkNaver() // TODO 회원 탈퇴 성공 시 api 호출
-                SocialLoginType.KAKAO -> kakaoSignService.unlinkKakao()
+                SocialLoginType.NAVER -> naverSignService.unlinkNaver(viewModel::deleteAccount) // TODO 회원 탈퇴 성공 시 api 호출
+                SocialLoginType.KAKAO -> kakaoSignService.unlinkKakao(viewModel::deleteAccount)
                 else -> {}
             }
         }
@@ -97,6 +98,19 @@ class MyActivity : BindingActivity<ActivityMyBinding>(R.layout.activity_my) {
                 }
                 is UiState.Error -> {} // TODO state에 따른 ui 업데이트 필요시 작성
                 is UiState.Loading -> {}
+                else -> {}
+            }
+        }.launchIn(lifecycleScope)
+
+        viewModel.isSuccessDeleteAccount.flowWithLifecycle(lifecycle).onEach {
+            when (it) {
+                is UiState.Success -> {
+                    startActivity(Intent(this, SignActivity::class.java))
+                    finish()
+                }
+                is UiState.Error -> {
+                    // TODO 회원 탈퇴 실패 시 예외 처리
+                }
                 else -> {}
             }
         }.launchIn(lifecycleScope)

--- a/app/src/main/java/org/keepgoeat/presentation/my/MyActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/my/MyActivity.kt
@@ -83,8 +83,8 @@ class MyActivity : BindingActivity<ActivityMyBinding>(R.layout.activity_my) {
         }
         binding.tvDeleteAccount.setOnClickListener {
             when (viewModel.loginPlatForm) {
-                SocialLoginType.NAVER -> naverSignService.unlinkNaver(viewModel::deleteAccount)
-                SocialLoginType.KAKAO -> kakaoSignService.unlinkKakao(viewModel::deleteAccount)
+                SocialLoginType.NAVER -> naverSignService.deleteAccountNaver(viewModel::deleteAccount)
+                SocialLoginType.KAKAO -> kakaoSignService.deleteAccountKakao(viewModel::deleteAccount)
                 else -> {}
             }
         }
@@ -115,7 +115,7 @@ class MyActivity : BindingActivity<ActivityMyBinding>(R.layout.activity_my) {
             }
         }.launchIn(lifecycleScope)
 
-        viewModel.isSuccessDeleteAccount.flowWithLifecycle(lifecycle).onEach {
+        viewModel.deleteAccountUiState.flowWithLifecycle(lifecycle).onEach {
             when (it) {
                 is UiState.Success -> {
                     startActivity(Intent(this, SignActivity::class.java))

--- a/app/src/main/java/org/keepgoeat/presentation/my/MyActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/my/MyActivity.kt
@@ -64,6 +64,12 @@ class MyActivity : BindingActivity<ActivityMyBinding>(R.layout.activity_my) {
         binding.ivBack.setOnClickListener {
             moveToPrevious()
         }
+        binding.tvLogout.setOnClickListener {
+            // TODO 로그아웃 로직 연결
+        }
+        binding.tvDeleteAccount.setOnClickListener {
+            // TODO 회원탈퇴 로직 연결
+        }
     }
 
     private fun collectData() {

--- a/app/src/main/java/org/keepgoeat/presentation/my/MyActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/my/MyActivity.kt
@@ -76,14 +76,14 @@ class MyActivity : BindingActivity<ActivityMyBinding>(R.layout.activity_my) {
         }
         binding.tvLogout.setOnClickListener {
             when (viewModel.loginPlatForm) {
-                SocialLoginType.NAVER -> naverSignService.logoutNaver()
-                SocialLoginType.KAKAO -> kakaoSignService.logoutKakao()
+                SocialLoginType.NAVER -> naverSignService.logoutNaver(viewModel::logout)
+                SocialLoginType.KAKAO -> kakaoSignService.logoutKakao(viewModel::logout)
                 else -> {}
             }
         }
         binding.tvDeleteAccount.setOnClickListener {
             when (viewModel.loginPlatForm) {
-                SocialLoginType.NAVER -> naverSignService.unlinkNaver(viewModel::deleteAccount) // TODO 회원 탈퇴 성공 시 api 호출
+                SocialLoginType.NAVER -> naverSignService.unlinkNaver(viewModel::deleteAccount)
                 SocialLoginType.KAKAO -> kakaoSignService.unlinkKakao(viewModel::deleteAccount)
                 else -> {}
             }
@@ -98,6 +98,19 @@ class MyActivity : BindingActivity<ActivityMyBinding>(R.layout.activity_my) {
                 }
                 is UiState.Error -> {} // TODO state에 따른 ui 업데이트 필요시 작성
                 is UiState.Loading -> {}
+                else -> {}
+            }
+        }.launchIn(lifecycleScope)
+
+        viewModel.logoutUiState.flowWithLifecycle(lifecycle).onEach {
+            when (it) {
+                is UiState.Success -> {
+                    startActivity(Intent(this, SignActivity::class.java))
+                    finish()
+                }
+                is UiState.Error -> {
+                    // TODO 로그아웃 실패 시 예외 처리
+                }
                 else -> {}
             }
         }.launchIn(lifecycleScope)

--- a/app/src/main/java/org/keepgoeat/presentation/my/MyViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/my/MyViewModel.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.keepgoeat.data.datasource.local.KGEDataSource
 import org.keepgoeat.domain.model.MyGoal
 import org.keepgoeat.domain.repository.MyRepository
 import org.keepgoeat.presentation.type.SortType
@@ -13,9 +14,13 @@ import org.keepgoeat.util.UiState
 import javax.inject.Inject
 
 @HiltViewModel
-class MyViewModel @Inject constructor(private val myRepository: MyRepository) : ViewModel() {
+class MyViewModel @Inject constructor(
+    private val myRepository: MyRepository,
+    private val localStorage: KGEDataSource,
+) : ViewModel() {
     private val _achievedGoalUiState = MutableStateFlow<UiState<List<MyGoal>>>(UiState.Loading)
     val achievedGoalUiState get() = _achievedGoalUiState.asStateFlow()
+    val loginPlatForm = localStorage.loginPlatform
 
     init {
         fetchAchievedGoalBySort(SortType.ALL)

--- a/app/src/main/java/org/keepgoeat/presentation/my/MyViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/my/MyViewModel.kt
@@ -22,7 +22,10 @@ class MyViewModel @Inject constructor(
 ) : ViewModel() {
     private val _achievedGoalUiState = MutableStateFlow<UiState<List<MyGoal>>>(UiState.Loading)
     val achievedGoalUiState get() = _achievedGoalUiState.asStateFlow()
-    private val _isSuccessDeleteAccount = MutableStateFlow<UiState<Boolean>>(UiState.Loading)
+    private val _logoutUiState = MutableStateFlow<UiState<Boolean>>(UiState.Loading)
+    val logoutUiState get() = _isSuccessDeleteAccount.asStateFlow()
+    private val _isSuccessDeleteAccount =
+        MutableStateFlow<UiState<Boolean>>(UiState.Loading) // TODO 변수명 수정
     val isSuccessDeleteAccount get() = _isSuccessDeleteAccount.asStateFlow()
     val loginPlatForm = localStorage.loginPlatform
 
@@ -36,9 +39,14 @@ class MyViewModel @Inject constructor(
                 .onSuccess {
                     _achievedGoalUiState.value = UiState.Success(it)
                 }.onFailure {
-                    _achievedGoalUiState.value = UiState.Error(it.message)
+                    _achievedGoalUiState.value = UiState.Error(null)
                 }
         }
+    }
+
+    fun logout() {
+        localStorage.clear()
+        _logoutUiState.value = UiState.Success(true)
     }
 
     fun deleteAccount() {

--- a/app/src/main/java/org/keepgoeat/presentation/my/MyViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/my/MyViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.keepgoeat.data.datasource.local.KGEDataSource
 import org.keepgoeat.domain.model.MyGoal
+import org.keepgoeat.domain.repository.AuthRepository
 import org.keepgoeat.domain.repository.MyRepository
 import org.keepgoeat.presentation.type.SortType
 import org.keepgoeat.util.UiState
@@ -16,10 +17,13 @@ import javax.inject.Inject
 @HiltViewModel
 class MyViewModel @Inject constructor(
     private val myRepository: MyRepository,
+    private val authRepository: AuthRepository,
     private val localStorage: KGEDataSource,
 ) : ViewModel() {
     private val _achievedGoalUiState = MutableStateFlow<UiState<List<MyGoal>>>(UiState.Loading)
     val achievedGoalUiState get() = _achievedGoalUiState.asStateFlow()
+    private val _isSuccessDeleteAccount = MutableStateFlow<UiState<Boolean>>(UiState.Loading)
+    val isSuccessDeleteAccount get() = _isSuccessDeleteAccount.asStateFlow()
     val loginPlatForm = localStorage.loginPlatform
 
     init {
@@ -33,6 +37,17 @@ class MyViewModel @Inject constructor(
                     _achievedGoalUiState.value = UiState.Success(it)
                 }.onFailure {
                     _achievedGoalUiState.value = UiState.Error(it.message)
+                }
+        }
+    }
+
+    fun deleteAccount() {
+        viewModelScope.launch {
+            authRepository.deleteAccount()
+                .onSuccess {
+                    _isSuccessDeleteAccount.value = UiState.Success(true)
+                }.onFailure {
+                    _isSuccessDeleteAccount.value = UiState.Error(it.message)
                 }
         }
     }

--- a/app/src/main/java/org/keepgoeat/presentation/my/MyViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/my/MyViewModel.kt
@@ -23,7 +23,7 @@ class MyViewModel @Inject constructor(
     private val _achievedGoalUiState = MutableStateFlow<UiState<List<MyGoal>>>(UiState.Loading)
     val achievedGoalUiState get() = _achievedGoalUiState.asStateFlow()
     private val _logoutUiState = MutableStateFlow<UiState<Boolean>>(UiState.Loading)
-    val logoutUiState get() = _deleteAccountUiState.asStateFlow()
+    val logoutUiState get() = _logoutUiState.asStateFlow()
     private val _deleteAccountUiState =
         MutableStateFlow<UiState<Boolean>>(UiState.Loading)
     val deleteAccountUiState get() = _deleteAccountUiState.asStateFlow()

--- a/app/src/main/java/org/keepgoeat/presentation/my/MyViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/my/MyViewModel.kt
@@ -23,10 +23,10 @@ class MyViewModel @Inject constructor(
     private val _achievedGoalUiState = MutableStateFlow<UiState<List<MyGoal>>>(UiState.Loading)
     val achievedGoalUiState get() = _achievedGoalUiState.asStateFlow()
     private val _logoutUiState = MutableStateFlow<UiState<Boolean>>(UiState.Loading)
-    val logoutUiState get() = _isSuccessDeleteAccount.asStateFlow()
-    private val _isSuccessDeleteAccount =
-        MutableStateFlow<UiState<Boolean>>(UiState.Loading) // TODO 변수명 수정
-    val isSuccessDeleteAccount get() = _isSuccessDeleteAccount.asStateFlow()
+    val logoutUiState get() = _deleteAccountUiState.asStateFlow()
+    private val _deleteAccountUiState =
+        MutableStateFlow<UiState<Boolean>>(UiState.Loading)
+    val deleteAccountUiState get() = _deleteAccountUiState.asStateFlow()
     val loginPlatForm = localStorage.loginPlatform
 
     init {
@@ -53,9 +53,9 @@ class MyViewModel @Inject constructor(
         viewModelScope.launch {
             authRepository.deleteAccount()
                 .onSuccess {
-                    _isSuccessDeleteAccount.value = UiState.Success(true)
+                    _deleteAccountUiState.value = UiState.Success(true)
                 }.onFailure {
-                    _isSuccessDeleteAccount.value = UiState.Error(it.message)
+                    _deleteAccountUiState.value = UiState.Error(it.message)
                 }
         }
     }

--- a/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
@@ -28,8 +28,9 @@ class SignViewModel @Inject constructor(
             authRepository.login(
                 RequestAuth(accessToken, loginPlatForm.name)
             ).onSuccess {
-                _loginUiState.value = UiState.Success(Pair(it?.type == SIGN_UP,
-                    localStorage.isClickedOnboardingButton))
+                _loginUiState.value = UiState.Success(
+                    Pair(it?.type == SIGN_UP, localStorage.isClickedOnboardingButton)
+                )
             }.onFailure {
                 _loginUiState.value = UiState.Error(it.message)
             }

--- a/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
@@ -1,0 +1,42 @@
+package org.keepgoeat.presentation.sign
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.keepgoeat.data.datasource.local.KGEDataSource
+import org.keepgoeat.data.model.request.RequestAuth
+import org.keepgoeat.domain.repository.AuthRepository
+import org.keepgoeat.presentation.type.SocialLoginType
+import org.keepgoeat.util.UiState
+import javax.inject.Inject
+
+@HiltViewModel
+class SignViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val localStorage: KGEDataSource,
+) :
+    ViewModel() {
+    private var _loginUiState = MutableStateFlow<UiState<Pair<Boolean, Boolean>>>(UiState.Loading)
+    val loginUiState get() = _loginUiState.asStateFlow()
+
+    fun login(loginPlatForm: SocialLoginType, accessToken: String) {
+        localStorage.loginPlatform = loginPlatForm
+        viewModelScope.launch {
+            authRepository.login(
+                RequestAuth(accessToken, loginPlatForm.name)
+            ).onSuccess {
+                _loginUiState.value = UiState.Success(Pair(it?.type == SIGN_UP,
+                    localStorage.isClickedOnboardingButton))
+            }.onFailure {
+                _loginUiState.value = UiState.Error(it.message)
+            }
+        }
+    }
+
+    companion object {
+        private const val SIGN_UP = "signup"
+    }
+}

--- a/app/src/main/java/org/keepgoeat/presentation/type/SocialLoginType.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/type/SocialLoginType.kt
@@ -1,0 +1,5 @@
+package org.keepgoeat.presentation.type
+
+enum class SocialLoginType {
+    NAVER, KAKAO, NONE
+}

--- a/app/src/main/java/org/keepgoeat/util/extension/ActivityExt.kt
+++ b/app/src/main/java/org/keepgoeat/util/extension/ActivityExt.kt
@@ -1,3 +1,5 @@
+package org.keepgoeat.util.extension
+
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment

--- a/app/src/main/res/layout/activity_my.xml
+++ b/app/src/main/res/layout/activity_my.xml
@@ -40,7 +40,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="@dimen/spacingBase"
-                android:text="로그아웃"
+                android:text="@string/my_logout"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/tv_delete_account"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -49,7 +49,7 @@
                 android:id="@+id/tv_delete_account"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="탈퇴"
+                android:text="@string/my_delete_account"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/activity_my.xml
+++ b/app/src/main/res/layout/activity_my.xml
@@ -34,6 +34,26 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
+            <!-- 계정 상세 뷰 전달받기 전까지 사용할 더미 뷰로, 뷰 전달 받은 이후 삭제 예정 -->
+            <TextView
+                android:id="@+id/tv_logout"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/spacingBase"
+                android:text="로그아웃"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/tv_delete_account"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_delete_account"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="탈퇴"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,8 +86,7 @@
     <string name="my_total_achievement_day">총 달성일</string>
     <string name="my_duration">진행기간</string>
     <string name="my_goal_duration_format">%s. %s. %s ~ %s. %s. %s</string>
-    <string name="goal_detail_delete_button_text">네, 삭제할래요</string>
-    <string name="goal_setting_success_edit_toast_message">목표가 수정되었습니다.</string>
-    <string name="goal_setting_success_add_toast_message">목표가 추가되었습니다.</string>
+    <string name="my_logout">로그아웃</string>
+    <string name="my_delete_account">탈퇴하기</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="goal_detail_hold">참은</string>
     <string name="goal_detail_success_goal_delete_toast_message">목표가 삭제되었습니다.</string>
     <string name="goal_detail_success_goal_keep_toast_message">목표가 보관되었습니다.</string>
+    <string name="goal_detail_delete_button_text">네, 삭제할래요</string>
 
     <!-- Home View -->
     <string name="home_today_goal">오늘 식습관 목표</string>
@@ -67,6 +68,8 @@
     <string name="goal_setting_title_length_guide">목표는 최소 1글자 이상 입력해주세요.</string>
     <string name="goal_setting_title_language_guide">한글, 영문, 숫자만 입력 가능합니다.</string>
     <string name="goal_setting_title_length_limit">(%d/15)</string>
+    <string name="goal_setting_success_edit_toast_message">목표가 수정되었습니다.</string>
+    <string name="goal_setting_success_add_toast_message">목표가 추가되었습니다.</string>
 
     <!-- On Boarding -->
     <string name="onboarding1_title">차근차근 식습관 목표를 세워보세요.</string>


### PR DESCRIPTION
## Related issue 🛠
- closed #152 

## Work Description ✏️
- 네이버 및 카카오 로그아웃 및 회원탈퇴 처리
- 로그아웃 시 로컬 데이터 삭제
- 회원탈퇴 시 api 요청 및 로컬 데이터 삭제
- 로그아웃 및 회원탈퇴 성공 여부에 따른 ui 업데이트 처리
- 로그인 로직 리팩토링

## Screenshot 📸
<img src="https://user-images.githubusercontent.com/48701368/218780037-73534338-697d-4d6b-a8e5-074ad0331ad7.png" width="360"/>

로그아웃 및 회원탈퇴 테스트는 마이페이지 우측 상단에 더미 뷰를 만들어두었으니 테스트 가능합니다!

## Uncompleted Tasks 😅
- [x] 백버튼 클릭 시 화면 전환 로직이 이상할 수 있습니다..! 요것은 마이페이지 ui 수정 완료 후에 해결하겠습니당! 일단 해당 문제가 발생하는 이유는 다음과 같습니다! 보관하기 눌렀을 때 마이페이지로 전환 처리를 하면서 해당 플로우에서 백버튼을 누르면 홈화면으로 이동해야하는 요구사항에 맞춰 백버튼 콜백을 달아두었고, 로그아웃 및 탈퇴로 해당 화면에 진입했을 때의 관련 백버튼 콜백 처리를 한다면 해결 될 것 입니다..! 하지만 마이페이지 플로우가 전면 수정됨에 따라 해당 플로우를 해결하기에는 저의 리소스 낭비 문제가 있겠죵.. 그래서 추후 수정하도록 할게용