### PR TITLE
[feat] 소셜 로그인에서 계정 정보 불러오기

### DIFF
--- a/app/src/main/java/org/keepgoeat/data/datasource/local/KGEDataSource.kt
+++ b/app/src/main/java/org/keepgoeat/data/datasource/local/KGEDataSource.kt
@@ -56,6 +56,14 @@ class KGEDataSource @Inject constructor(@ApplicationContext context: Context) {
         get() = safeValueOf<SocialLoginType>(dataStore.getString(LOGIN_PLATFORM, ""))
             ?: SocialLoginType.NONE
 
+    var userEmail: String
+        set(value) = dataStore.edit { putString(USER_EMAIL, value) }
+        get() = dataStore.getString(USER_EMAIL, "") ?: ""
+
+    var userName: String
+        set(value) = dataStore.edit { putString(USER_NAME, value) }
+        get() = dataStore.getString(USER_NAME, "") ?: ""
+
     /** 로그아웃 및 회원 탈퇴 시 유저의 데이터를 삭제하는 함수 (단, 로그아웃의 경우 IS_CLICKED_ONBOARDING_BUTTON은 제외하고 삭제한다. 재로그인 시 온보딩 띄우기를 방지하기 위함)*/
     fun clear(isWithdrawal: Boolean = false) {
         dataStore.edit {
@@ -66,6 +74,8 @@ class KGEDataSource @Inject constructor(@ApplicationContext context: Context) {
                 remove(REFRESH_TOKEN)
                 remove(IS_LOGIN)
                 remove(LOGIN_PLATFORM)
+                remove(USER_NAME)
+                remove(USER_EMAIL)
             }
         }
     }
@@ -77,5 +87,7 @@ class KGEDataSource @Inject constructor(@ApplicationContext context: Context) {
         const val IS_LOGIN = "isLogin"
         const val IS_CLICKED_ONBOARDING_BUTTON = "isClickedOnboardingButton"
         const val LOGIN_PLATFORM = "loginPlatform"
+        const val USER_EMAIL = "userEmail"
+        const val USER_NAME = "userName"
     }
 }

--- a/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.user.UserApiClient
 import dagger.hilt.android.qualifiers.ActivityContext
-import org.keepgoeat.domain.model.UserInfo
+import org.keepgoeat.domain.model.AccountInfo
 import org.keepgoeat.presentation.type.SocialLoginType
 import timber.log.Timber
 import javax.inject.Inject
@@ -16,7 +16,7 @@ class KakaoAuthService @Inject constructor(
     private val isKakaoTalkLoginAvailable: Boolean
         get() = client.isKakaoTalkLoginAvailable(context)
 
-    fun loginKakao(loginListener: ((SocialLoginType, String, UserInfo) -> Unit)) {
+    fun loginKakao(loginListener: ((SocialLoginType, String, AccountInfo) -> Unit)) {
         val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
             if (error != null) handleLoginError(error)
             else if (token != null) handleLoginSuccess(token, loginListener)
@@ -33,7 +33,7 @@ class KakaoAuthService @Inject constructor(
 
     private fun handleLoginSuccess(
         oAuthToken: OAuthToken,
-        loginListener: ((SocialLoginType, String, UserInfo) -> Unit),
+        loginListener: ((SocialLoginType, String, AccountInfo) -> Unit),
     ) {
         client.me { user, error ->
             Timber.d(oAuthToken.accessToken)
@@ -44,7 +44,7 @@ class KakaoAuthService @Inject constructor(
                 loginListener(
                     SocialLoginType.KAKAO,
                     oAuthToken.accessToken,
-                    UserInfo(user.kakaoAccount?.name ?: "", user.kakaoAccount?.email ?: "")
+                    AccountInfo(user.kakaoAccount?.name ?: "", user.kakaoAccount?.email ?: "")
                 )
             }
         }

--- a/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.user.UserApiClient
 import dagger.hilt.android.qualifiers.ActivityContext
+import org.keepgoeat.domain.model.UserInfo
 import org.keepgoeat.presentation.type.SocialLoginType
 import timber.log.Timber
 import javax.inject.Inject
@@ -15,7 +16,7 @@ class KakaoAuthService @Inject constructor(
     private val isKakaoTalkLoginAvailable: Boolean
         get() = client.isKakaoTalkLoginAvailable(context)
 
-    fun loginKakao(loginListener: ((SocialLoginType, String) -> Unit)) {
+    fun loginKakao(loginListener: ((SocialLoginType, String, UserInfo) -> Unit)) {
         val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
             if (error != null) handleLoginError(error)
             else if (token != null) handleLoginSuccess(token, loginListener)
@@ -32,11 +33,20 @@ class KakaoAuthService @Inject constructor(
 
     private fun handleLoginSuccess(
         oAuthToken: OAuthToken,
-        loginListener: ((SocialLoginType, String) -> Unit),
+        loginListener: ((SocialLoginType, String, UserInfo) -> Unit),
     ) {
-        client.me { _, _ ->
+        client.me { user, error ->
             Timber.d(oAuthToken.accessToken)
-            loginListener(SocialLoginType.KAKAO, oAuthToken.accessToken)
+            if (error != null) {
+                Timber.e("kakao 사용자 정보 요청 실패 ${error}")
+            } else if (user != null) {
+                Timber.d("kakao 사용자 정보 요청 성공\n이메일 : ${user.kakaoAccount?.email}\n이름 : ${user.kakaoAccount?.name}")
+                loginListener(
+                    SocialLoginType.KAKAO,
+                    oAuthToken.accessToken,
+                    UserInfo(user.kakaoAccount?.name ?: "", user.kakaoAccount?.email ?: "")
+                )
+            }
         }
     }
 

--- a/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/KakaoAuthService.kt
@@ -38,7 +38,7 @@ class KakaoAuthService @Inject constructor(
         client.me { user, error ->
             Timber.d(oAuthToken.accessToken)
             if (error != null) {
-                Timber.e("kakao 사용자 정보 요청 실패 ${error}")
+                Timber.e("kakao 사용자 정보 요청 실패 $error")
             } else if (user != null) {
                 Timber.d("kakao 사용자 정보 요청 성공\n이메일 : ${user.kakaoAccount?.email}\n이름 : ${user.kakaoAccount?.name}")
                 loginListener(

--- a/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
@@ -59,7 +59,7 @@ class NaverAuthService @Inject constructor(
             }
 
             override fun onFailure(httpStatus: Int, message: String) {
-                Timber.i("Error : ${httpStatus}, message : $message")
+                Timber.i("Error : $httpStatus, message : $message")
             }
 
             override fun onError(errorCode: Int, message: String) {

--- a/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
@@ -23,12 +23,16 @@ class NaverAuthService @Inject constructor(
         )
     }
 
-    fun loginNaver(loginListener: ((SocialLoginType, String, AccountInfo) -> Unit)) {
+    fun loginNaver(
+        loginListener: ((SocialLoginType, String) -> Unit),
+        accountListener: (AccountInfo) -> Unit
+    ) {
         val oauthLoginCallback = object : OAuthLoginCallback {
             override fun onSuccess() {
                 val accessToken = requireNotNull(NaverIdLoginSDK.getAccessToken())
                 Timber.d(accessToken)
-                getAccountInfo(accessToken, loginListener)
+                loginListener(SocialLoginType.NAVER, accessToken)
+                getAccountInfo(accountListener)
             }
 
             override fun onFailure(httpStatus: Int, message: String) {
@@ -45,16 +49,14 @@ class NaverAuthService @Inject constructor(
         )
     }
 
-    fun getAccountInfo(
-        accessToken: String,
-        loginListener: ((SocialLoginType, String, AccountInfo) -> Unit)
-    ) {
+    fun getAccountInfo(accountListener: (AccountInfo) -> Unit) {
         NidOAuthLogin().callProfileApi(object : NidProfileCallback<NidProfileResponse> {
             override fun onSuccess(result: NidProfileResponse) {
-                loginListener(
-                    SocialLoginType.NAVER,
-                    accessToken,
-                    AccountInfo(result.profile?.name ?: "", result.profile?.email ?: "")
+                accountListener(
+                    AccountInfo(
+                        result.profile?.name ?: "",
+                        result.profile?.email ?: ""
+                    )
                 )
             }
 

--- a/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
+++ b/app/src/main/java/org/keepgoeat/data/service/NaverAuthService.kt
@@ -4,8 +4,11 @@ import android.content.Context
 import com.navercorp.nid.NaverIdLoginSDK
 import com.navercorp.nid.oauth.NidOAuthLogin
 import com.navercorp.nid.oauth.OAuthLoginCallback
+import com.navercorp.nid.profile.NidProfileCallback
+import com.navercorp.nid.profile.data.NidProfileResponse
 import dagger.hilt.android.qualifiers.ActivityContext
 import org.keepgoeat.BuildConfig
+import org.keepgoeat.domain.model.AccountInfo
 import org.keepgoeat.presentation.type.SocialLoginType
 import timber.log.Timber
 import javax.inject.Inject
@@ -20,12 +23,12 @@ class NaverAuthService @Inject constructor(
         )
     }
 
-    fun loginNaver(loginListener: ((SocialLoginType, String) -> Unit)) {
+    fun loginNaver(loginListener: ((SocialLoginType, String, AccountInfo) -> Unit)) {
         val oauthLoginCallback = object : OAuthLoginCallback {
             override fun onSuccess() {
                 val accessToken = requireNotNull(NaverIdLoginSDK.getAccessToken())
                 Timber.d(accessToken)
-                loginListener(SocialLoginType.NAVER, accessToken)
+                getAccountInfo(accessToken, loginListener)
             }
 
             override fun onFailure(httpStatus: Int, message: String) {
@@ -40,6 +43,29 @@ class NaverAuthService @Inject constructor(
         NaverIdLoginSDK.authenticate(
             context, oauthLoginCallback
         )
+    }
+
+    fun getAccountInfo(
+        accessToken: String,
+        loginListener: ((SocialLoginType, String, AccountInfo) -> Unit)
+    ) {
+        NidOAuthLogin().callProfileApi(object : NidProfileCallback<NidProfileResponse> {
+            override fun onSuccess(result: NidProfileResponse) {
+                loginListener(
+                    SocialLoginType.NAVER,
+                    accessToken,
+                    AccountInfo(result.profile?.name ?: "", result.profile?.email ?: "")
+                )
+            }
+
+            override fun onFailure(httpStatus: Int, message: String) {
+                Timber.i("Error : ${httpStatus}, message : $message")
+            }
+
+            override fun onError(errorCode: Int, message: String) {
+                onFailure(errorCode, message)
+            }
+        })
     }
 
     fun logoutNaver(logoutListener: (() -> Unit)) {

--- a/app/src/main/java/org/keepgoeat/domain/model/AccountInfo.kt
+++ b/app/src/main/java/org/keepgoeat/domain/model/AccountInfo.kt
@@ -1,6 +1,6 @@
 package org.keepgoeat.domain.model
 
-data class UserInfo(
+data class AccountInfo(
     val name: String,
     val email: String,
 )

--- a/app/src/main/java/org/keepgoeat/domain/model/UserInfo.kt
+++ b/app/src/main/java/org/keepgoeat/domain/model/UserInfo.kt
@@ -1,0 +1,6 @@
+package org.keepgoeat.domain.model
+
+data class UserInfo(
+    val name: String,
+    val email: String,
+)

--- a/app/src/main/java/org/keepgoeat/presentation/my/MyViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/my/MyViewModel.kt
@@ -28,6 +28,8 @@ class MyViewModel @Inject constructor(
         MutableStateFlow<UiState<Boolean>>(UiState.Loading)
     val deleteAccountUiState get() = _deleteAccountUiState.asStateFlow()
     val loginPlatForm = localStorage.loginPlatform
+    val userName = localStorage.userName
+    val userEmail = localStorage.userEmail
 
     fun fetchAchievedGoalBySort(sortType: SortType) {
         viewModelScope.launch {

--- a/app/src/main/java/org/keepgoeat/presentation/sign/SignActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/sign/SignActivity.kt
@@ -36,10 +36,10 @@ class SignActivity : BindingActivity<ActivitySignBinding>(R.layout.activity_sign
 
     private fun addListeners() {
         binding.layoutKakaoSignIn.setOnClickListener {
-            kakaoSignService.loginKakao(viewModel::login)
+            kakaoSignService.loginKakao(viewModel::login, viewModel::saveAccount)
         }
         binding.layoutNaverSignIn.setOnClickListener {
-            naverSignService.loginNaver(viewModel::login)
+            naverSignService.loginNaver(viewModel::login, viewModel::saveAccount)
         }
     }
 

--- a/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
@@ -23,10 +23,8 @@ class SignViewModel @Inject constructor(
     private var _loginUiState = MutableStateFlow<UiState<Pair<Boolean, Boolean>>>(UiState.Loading)
     val loginUiState get() = _loginUiState.asStateFlow()
 
-    fun login(loginPlatForm: SocialLoginType, accessToken: String, accountInfo: AccountInfo) {
+    fun login(loginPlatForm: SocialLoginType, accessToken: String) {
         localStorage.loginPlatform = loginPlatForm
-        localStorage.userName = accountInfo.name
-        localStorage.userEmail = accountInfo.email
         viewModelScope.launch {
             authRepository.login(
                 RequestAuth(accessToken, loginPlatForm.name)
@@ -38,6 +36,11 @@ class SignViewModel @Inject constructor(
                 _loginUiState.value = UiState.Error(it.message)
             }
         }
+    }
+
+    fun saveAccount(accountInfo: AccountInfo) {
+        localStorage.userName = accountInfo.name
+        localStorage.userEmail = accountInfo.email
     }
 
     companion object {

--- a/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.keepgoeat.data.datasource.local.KGEDataSource
 import org.keepgoeat.data.model.request.RequestAuth
+import org.keepgoeat.domain.model.AccountInfo
 import org.keepgoeat.domain.repository.AuthRepository
 import org.keepgoeat.presentation.type.SocialLoginType
 import org.keepgoeat.util.UiState
@@ -22,8 +23,10 @@ class SignViewModel @Inject constructor(
     private var _loginUiState = MutableStateFlow<UiState<Pair<Boolean, Boolean>>>(UiState.Loading)
     val loginUiState get() = _loginUiState.asStateFlow()
 
-    fun login(loginPlatForm: SocialLoginType, accessToken: String) {
+    fun login(loginPlatForm: SocialLoginType, accessToken: String, accountInfo: AccountInfo) {
         localStorage.loginPlatform = loginPlatForm
+        localStorage.userName = accountInfo.name
+        localStorage.userEmail = accountInfo.email
         viewModelScope.launch {
             authRepository.login(
                 RequestAuth(accessToken, loginPlatForm.name)

--- a/app/src/main/res/layout/activity_my.xml
+++ b/app/src/main/res/layout/activity_my.xml
@@ -33,7 +33,6 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
-                <!-- TODO 유저 이름 및 이메일 불러오기 -->
                 <TextView
                     android:id="@+id/tv_user_name"
                     android:layout_width="wrap_content"
@@ -42,7 +41,7 @@
                     android:layout_marginStart="@dimen/spacing16"
                     android:layout_marginTop="28dp"
                     android:gravity="center_vertical"
-                    android:text="user214"
+                    android:text="@{viewModel.userName}"
                     android:textAppearance="@style/TextAppearance.System3_Bold"
                     android:textColor="@color/gray_800"
                     app:drawableEndCompat="@drawable/ic_detail"
@@ -53,7 +52,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/spacing16"
-                    android:text="keepgoeat@kakao.com"
+                    android:text="@{viewModel.userEmail}"
                     android:textAppearance="@style/TextAppearance.System5"
                     android:textColor="@color/gray_600"
                     tools:text="keepgoeat@kakao.com" />


### PR DESCRIPTION
## Related issue 🛠
- closed #160

## Work Description ✏️
- 네이버 로그인에서 계정 정보 불러오기
- 카카오 로그인에서 계정 정보 불러오기
- 마이페이지에 계정 정보 데이터 바인딩

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [x] 계정 정보 활용 요청을 따로 코드로 호출해서 확인해야 하는 건지 확인 필요 ->처음 가입시에만 확인하고 탈퇴하지 않는 이상 따로 확인 안해도 되는건지, 이 부분 코드 구현해야 되는 건지 알아보기
