### PR TITLE
[feat] 홈 뷰에 네트워크 에러 핸들링 적용

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:name=".App"

--- a/app/src/main/java/org/keepgoeat/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/home/HomeActivity.kt
@@ -122,7 +122,6 @@ class HomeActivity : BindingActivity<ActivityHomeBinding>(R.layout.activity_home
         terminateNetworkCallback()
     }
 
-
     private fun showMakeGoalDialog() {
         HomeBottomDialogFragment().show(supportFragmentManager, "homeDialog")
     }

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -135,6 +135,29 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
             </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_network_error"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:background="@color/gray_600"
+                android:visibility="visible"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginVertical="@dimen/spacing16"
+                    android:text="네트워크를 연결을 확인해 주세요."
+                    android:textAppearance="@style/TextAppearance.System4_Bold"
+                    android:textColor="@color/gray_50"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.recyclerview.widget.RecyclerView


### PR DESCRIPTION
## Related issue 🛠
- #169

## Work Description ✏️
- 홈 뷰에 네트워크 에러 핸들링 적용
- 네트워크 감지해서 Visibility 조정하는 방식으로 구현했습니당!!

## Screenshot 📸
<img src="https://user-images.githubusercontent.com/74285061/221364732-77c713d0-31c2-4fe4-9a2d-8b32928b3f89.png" width="360"/>

## Uncompleted Tasks 😅
- [ ] 전체 뷰에 적용해보진 않았구 홈 뷰에만 일단 맛보기로 테스트해보았습니당
