### PR TITLE
[fix] 회원탈퇴 성공 후 로그인화면으로 이동했을 때 백버튼을 누르면 다시 회원탈퇴 화면이 보이는 버그 수정

### DIFF
--- a/app/src/main/java/org/keepgoeat/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/org/keepgoeat/data/interceptor/AuthInterceptor.kt
@@ -19,13 +19,15 @@ import javax.inject.Inject
 class AuthInterceptor @Inject constructor(
     private val localStorage: KGEDataSource,
     private val gson: Gson,
-    private val context: Application
+    private val context: Application,
 ) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
         val authRequest =
-            originalRequest.newBuilder().addHeader(ACCESS_TOKEN, localStorage.accessToken).build()
+            originalRequest.newBuilder()
+                .addHeader(ACCESS_TOKEN, localStorage.accessToken)
+                .addHeader(REFRESH_TOKEN, localStorage.refreshToken).build()
         val response = chain.proceed(authRequest)
 
         when (response.code) {

--- a/app/src/main/java/org/keepgoeat/presentation/withdraw/WithdrawDialogFragment.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/withdraw/WithdrawDialogFragment.kt
@@ -15,7 +15,6 @@ import org.keepgoeat.data.service.NaverAuthService
 import org.keepgoeat.databinding.DialogWithdrawBinding
 import org.keepgoeat.presentation.home.HomeActivity
 import org.keepgoeat.presentation.my.MyViewModel
-import org.keepgoeat.presentation.sign.SignActivity
 import org.keepgoeat.presentation.type.SocialLoginType
 import org.keepgoeat.util.UiState
 import org.keepgoeat.util.binding.BindingDialogFragment
@@ -57,6 +56,7 @@ class WithdrawDialogFragment :
                 is UiState.Success -> {
                     requireActivity().showToast(getString(R.string.withdraw_success))
                     moveToSign()
+                    dismiss()
                 }
                 is UiState.Error -> {
                     requireActivity().showToast(getString(R.string.withdraw_fail))
@@ -68,12 +68,11 @@ class WithdrawDialogFragment :
     }
 
     private fun moveToSign() {
-        Intent(context, SignActivity::class.java).apply {
+        Intent(context, HomeActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
             putExtra(HomeActivity.ARG_KILL_HOME_AND_GO_TO_SIGN, true)
         }.also {
             startActivity(it)
-            dismiss()
         }
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #197

## Work Description ✏️
- 회원 탈퇴 성공 시 홈화면으로(flag: CLEAR_TOP) 이동, 이때 sign 화면으로 이동하도록 data(ARG_KILL_HOME_AND_GO_TO_SIGN, true)를 함께 전달 -> 로그아웃 플로우랑 동일
