### PR TITLE
[fix] 탈퇴 뷰 직접입력 클릭했을 때 깜빡이는 이슈 해결

### DIFF
--- a/app/src/main/java/org/keepgoeat/presentation/withdraw/WithdrawActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/withdraw/WithdrawActivity.kt
@@ -95,17 +95,18 @@ class WithdrawActivity : BindingActivity<ActivityWithdrawBinding>(R.layout.activ
             if (isValid)
                 binding.tvOtherReasonErrorMsg.setVisibility(false)
         }.launchIn(lifecycleScope)
+        viewModel.isKeyboardVisible.flowWithLifecycle(lifecycle).onEach { isVisible ->
+            binding.rvWithdraw.setVisibility(!isVisible)
+        }.launchIn(lifecycleScope)
     }
 
     private fun clearFocus() {
         binding.etOtherReason.clearFocus()
-        viewModel.setKeyboardVisibility(false)
         showKeyboard(binding.etOtherReason, false)
     }
 
     private fun requestFocus() {
         binding.etOtherReason.requestFocus()
-        viewModel.setKeyboardVisibility(true)
         showKeyboard(binding.etOtherReason, true)
     }
 

--- a/app/src/main/res/layout/activity_withdraw.xml
+++ b/app/src/main/res/layout/activity_withdraw.xml
@@ -57,8 +57,7 @@
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tv_withdraw_description"
-            app:visibility="@{!viewModel.isKeyboardVisible}" />
+            app:layout_constraintTop_toBottomOf="@+id/tv_withdraw_description" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_other_reason"


### PR DESCRIPTION
## Related issue 🛠
- #204

## Work Description ✏️
- 탈퇴 뷰 직접입력 클릭했을 때 깜빡이는 이슈 해결

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅

