### PR TITLE
[fix] 토큰 갱신 성공 후 api 재요청할 경우, 400 에러가 뜨는 버그 수정

### DIFF
--- a/app/src/main/java/org/keepgoeat/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/org/keepgoeat/data/interceptor/AuthInterceptor.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import okhttp3.Interceptor
+import okhttp3.Request
 import okhttp3.Response
 import org.keepgoeat.BuildConfig
 import org.keepgoeat.R
@@ -24,10 +25,7 @@ class AuthInterceptor @Inject constructor(
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
-        val authRequest =
-            originalRequest.newBuilder()
-                .addHeader(ACCESS_TOKEN, localStorage.accessToken)
-                .addHeader(REFRESH_TOKEN, localStorage.refreshToken).build()
+        val authRequest = originalRequest.newAuthBuilder().build()
         val response = chain.proceed(authRequest)
 
         when (response.code) {
@@ -49,10 +47,7 @@ class AuthInterceptor @Inject constructor(
                         accessToken = responseRefresh.data.accessToken
                         refreshToken = responseRefresh.data.refreshToken
                     }
-                    val newRequest =
-                        originalRequest.newBuilder()
-                            .addHeader(ACCESS_TOKEN, localStorage.accessToken)
-                            .build()
+                    val newRequest = originalRequest.newAuthBuilder().build()
                     return chain.proceed(newRequest)
                 } else {
                     with(context) {
@@ -72,6 +67,11 @@ class AuthInterceptor @Inject constructor(
         }
         return response
     }
+
+    private fun Request.newAuthBuilder() =
+        this.newBuilder()
+            .addHeader(ACCESS_TOKEN, localStorage.accessToken)
+            .addHeader(REFRESH_TOKEN, localStorage.refreshToken)
 
     companion object {
         private const val ACCESS_TOKEN = "accesstoken"


### PR DESCRIPTION
## Related issue 🛠
- closed #208

## Work Description ✏️
- api 요청 및 재요청 시 사용되는 Request.Builder를 생성하는 확장함수를 추가
   - 재요청 시 사용되는 requestBuilder에 refreshToken 헤더만 추가하려고 했으나 추후 또다른 헤더가 추가될 경우 각 builder마다 동일한 헤더를 변경해야하는 상황을 고려해서 확장함수로 만들어두고 헤더에 변경사항이 생기면 해당 확장함수만 수정하여 두 builder에 반영되도록 하기 위함.

