### PR TITLE
[fix] 네트워크 연결 상태에서도 종종 네트워크 에러뷰가 보이는 버그 수정

### DIFF
--- a/app/src/main/java/org/keepgoeat/util/NetworkMonitor.kt
+++ b/app/src/main/java/org/keepgoeat/util/NetworkMonitor.kt
@@ -3,26 +3,19 @@ package org.keepgoeat.util
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Network
-import android.net.NetworkCapabilities
-import android.net.NetworkRequest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import org.keepgoeat.util.extension.toStateFlow
 
+/* ref :
+https://developer.android.com/training/basics/network-ops/reading-network-state
+https://medium.com/@bazzairvine/observing-your-network-connection-with-flow-1cdedf31780c */
+
 class NetworkMonitor(private val context: Context, private val coroutineScope: CoroutineScope) {
     private var connectivityManager: ConnectivityManager =
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-
-    private val request = NetworkRequest.Builder()
-        .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-        .apply {
-            addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
-        }
-        .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
-        .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
-        .build()
 
     val isConnected: StateFlow<Boolean> = callbackFlow {
         val callback = object : ConnectivityManager.NetworkCallback() {
@@ -37,7 +30,7 @@ class NetworkMonitor(private val context: Context, private val coroutineScope: C
             }
         }
 
-        connectivityManager.registerNetworkCallback(request, callback)
+        connectivityManager.registerDefaultNetworkCallback(callback)
 
         awaitClose {
             connectivityManager.unregisterNetworkCallback(callback)


### PR DESCRIPTION
## Related issue 🛠
- closed #212

## Work Description ✏️
- 콜백 등록 시 registerNetworkCallback -> registerDefaultNetworkCallback 으로 변경
   - 에러 발생 환경 : 셀룰러 및 와이파이 모두 연결되어있는 상태에서 **디폴트 네트워크가 와아피이로 잡혀있을 때** 와이파이를 연결 해제한다면 디폴트 네트워크가 **와이파이 -> 셀룰러로 변경**이 됨.

   - 버그 원인 : 기존 코드로는 **디폴트 네트워크 변경 감지 못함.** 따라서 와이파이 연결해제되면 셀룰러가 켜져있다고 하더라도 에러뷰가 보였던 것임. 다시 말해 와이파이에 대한 `NeworkCallback > onLost()`만 호출되고, 변경된 디폴트 네트워크 즉, 셀룰러에 대한 `NeworkCallback > onAvailable()`가 호출되지 않아 발생한 버그.

   - 버그 해결 : 디폴트 네트워크가 변경을 감지해서 해당 네트워크에 대한 onAvailable() 함수가 호출될 수 있도록 **registerDefaultNetworkCallback**으로 변경함.

   - 참고 : [공식문서](https://developer.android.com/training/basics/network-ops/reading-network-state)
      - registerDefaultNetworkCallback은 **api 레벨 24**부터 추가됨(킵고잇 minSdk 28이기 때문에 os 버전에 따른 분기처리 없이 사용)
      - 공식문서에 따르면 **네트워크 변경 감지가 중요한 앱인 경우, defaultNetworkCallback을 등록**하라함.
          >  If it is important for the app to know when the default network changes, it registers a default network callback as follows

- 불필요한 request: NetworkRequest 변수 삭제 
