### PR TITLE
[feat] 믹스패널 목표 관련 이벤트 추가 및 수정

### DIFF
--- a/app/src/main/java/org/keepgoeat/presentation/common/BaseViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/common/BaseViewModel.kt
@@ -2,4 +2,4 @@ package org.keepgoeat.presentation.common
 
 import androidx.lifecycle.ViewModel
 
-abstract class BaseViewModel : ViewModel() {}
+abstract class BaseViewModel : ViewModel()

--- a/app/src/main/java/org/keepgoeat/presentation/common/BaseViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/common/BaseViewModel.kt
@@ -1,0 +1,5 @@
+package org.keepgoeat.presentation.common
+
+import androidx.lifecycle.ViewModel
+
+abstract class BaseViewModel : ViewModel() {}

--- a/app/src/main/java/org/keepgoeat/presentation/common/MixpanelViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/common/MixpanelViewModel.kt
@@ -1,0 +1,17 @@
+package org.keepgoeat.presentation.common
+
+import org.keepgoeat.util.mixpanel.MixpanelProvider
+import javax.inject.Inject
+
+abstract class MixpanelViewModel : BaseViewModel() {
+    @Inject
+    lateinit var mixpanelProvider: MixpanelProvider
+
+    fun startRecodingScreenTime() {
+        mixpanelProvider.startRecodingScreenTime()
+    }
+
+    fun stopRecodingScreenTime(screenName: String) {
+        mixpanelProvider.stopRecodingScreenTime(screenName)
+    }
+}

--- a/app/src/main/java/org/keepgoeat/presentation/detail/GoalDeleteBottomDialogFragment.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/detail/GoalDeleteBottomDialogFragment.kt
@@ -20,9 +20,23 @@ class GoalDeleteBottomDialogFragment :
         addListeners()
     }
 
+    override fun onStart() {
+        super.onStart()
+        viewModel.startRecodingScreenTime()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        viewModel.stopRecodingScreenTime(SCREEN_NAME)
+    }
+
     private fun addListeners() {
         binding.btnNo.setOnClickListener {
             dismiss()
         }
+    }
+
+    companion object {
+        private const val SCREEN_NAME = "goal delete"
     }
 }

--- a/app/src/main/java/org/keepgoeat/presentation/detail/GoalDetailActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/detail/GoalDetailActivity.kt
@@ -59,6 +59,16 @@ class GoalDetailActivity :
         collectData()
     }
 
+    override fun onStart() {
+        super.onStart()
+        viewModel.startRecodingScreenTime()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        viewModel.stopRecodingScreenTime(SCREEN_NAME)
+    }
+
     private fun initLayout() {
         binding.rvGoalCard.apply {
             addItemDecoration(
@@ -147,5 +157,6 @@ class GoalDetailActivity :
         const val ARG_EATING_TYPE = "eatingType"
         const val ARG_GOAL_ID = "goalId"
         const val ARG_HOME_GOAL_COUNT = "homeGoalCount"
+        private const val SCREEN_NAME = "goal detail"
     }
 }

--- a/app/src/main/java/org/keepgoeat/presentation/detail/GoalDetailViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/detail/GoalDetailViewModel.kt
@@ -1,6 +1,5 @@
 package org.keepgoeat.presentation.detail
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -9,18 +8,16 @@ import kotlinx.coroutines.launch
 import org.keepgoeat.domain.model.GoalDetail
 import org.keepgoeat.domain.model.GoalSticker
 import org.keepgoeat.domain.repository.GoalRepository
+import org.keepgoeat.presentation.common.MixpanelViewModel
 import org.keepgoeat.util.UiState
 import org.keepgoeat.util.mixpanel.GoalEvent
-import org.keepgoeat.util.mixpanel.MixpanelProvider
 import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class GoalDetailViewModel @Inject constructor(
     private val goalRepository: GoalRepository,
-    private val mixpanelProvider: MixpanelProvider,
-) :
-    ViewModel() {
+) : MixpanelViewModel() {
     private val _goalStickers = MutableStateFlow<List<GoalSticker>>(emptyList())
     val goalStickers get() = _goalStickers.asStateFlow()
     private val _goalDetail = MutableStateFlow<GoalDetail?>(null)

--- a/app/src/main/java/org/keepgoeat/presentation/detail/GoalKeepBottomDialogFragment.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/detail/GoalKeepBottomDialogFragment.kt
@@ -14,7 +14,7 @@ import org.keepgoeat.util.UiState
 import org.keepgoeat.util.binding.BindingBottomSheetDialogFragment
 
 @AndroidEntryPoint
-class GoalKeepBottomDialogFragment :
+class GoalKeepBottomDialogFragment : // TODO 네이밍 수정 keep -> archive
     BindingBottomSheetDialogFragment<DialogBottomGoalKeepBinding>(R.layout.dialog_bottom_goal_keep) {
     private val viewModel: GoalDetailViewModel by activityViewModels()
 
@@ -24,6 +24,16 @@ class GoalKeepBottomDialogFragment :
 
         addListeners()
         collectData()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        viewModel.startRecodingScreenTime()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        viewModel.stopRecodingScreenTime(SCREEN_NAME)
     }
 
     private fun addListeners() {
@@ -46,5 +56,9 @@ class GoalKeepBottomDialogFragment :
     private fun showGoalDeleteDialog() {
         GoalDeleteBottomDialogFragment().show(parentFragmentManager, "goalDeleteDialog")
         dismiss()
+    }
+
+    companion object {
+        private const val SCREEN_NAME = "goal archive"
     }
 }

--- a/app/src/main/java/org/keepgoeat/presentation/home/HomeBottomDialogFragment.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/home/HomeBottomDialogFragment.kt
@@ -4,12 +4,14 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
 import org.keepgoeat.R
 import org.keepgoeat.databinding.DialogBottomHomeBinding
 import org.keepgoeat.presentation.setting.GoalSettingActivity
 import org.keepgoeat.presentation.type.EatingType
 import org.keepgoeat.util.binding.BindingBottomSheetDialogFragment
 
+@AndroidEntryPoint
 class HomeBottomDialogFragment :
     BindingBottomSheetDialogFragment<DialogBottomHomeBinding>(R.layout.dialog_bottom_home) {
     private val viewModel: HomeViewModel by viewModels()

--- a/app/src/main/java/org/keepgoeat/presentation/home/HomeBottomDialogFragment.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/home/HomeBottomDialogFragment.kt
@@ -3,6 +3,7 @@ package org.keepgoeat.presentation.home
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import androidx.fragment.app.viewModels
 import org.keepgoeat.R
 import org.keepgoeat.databinding.DialogBottomHomeBinding
 import org.keepgoeat.presentation.setting.GoalSettingActivity
@@ -11,6 +12,8 @@ import org.keepgoeat.util.binding.BindingBottomSheetDialogFragment
 
 class HomeBottomDialogFragment :
     BindingBottomSheetDialogFragment<DialogBottomHomeBinding>(R.layout.dialog_bottom_home) {
+    private val viewModel: HomeViewModel by viewModels()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         addListeners()
@@ -19,9 +22,11 @@ class HomeBottomDialogFragment :
     private fun addListeners() {
         binding.layoutHomeBottomMore.setOnClickListener {
             moveToSetting(EatingType.MORE)
+            viewModel.sendGoalAddEvent(EatingType.MORE)
         }
         binding.layoutHomeBottomLess.setOnClickListener {
             moveToSetting(EatingType.LESS)
+            viewModel.sendGoalAddEvent(EatingType.LESS)
         }
     }
 

--- a/app/src/main/java/org/keepgoeat/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/home/HomeViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.launch
 import org.keepgoeat.domain.model.HomeContent
 import org.keepgoeat.domain.model.HomeGoal
 import org.keepgoeat.domain.repository.GoalRepository
+import org.keepgoeat.presentation.type.EatingType
 import org.keepgoeat.presentation.type.ProcessState
 import org.keepgoeat.util.UiState
 import org.keepgoeat.util.mixpanel.GoalEvent
@@ -96,5 +97,10 @@ class HomeViewModel @Inject constructor(
 
     fun changeLottieState(state: ProcessState) {
         _lottieState.value = state
+    }
+
+    fun sendGoalAddEvent(eatingType: EatingType) {
+        val goalType = if (eatingType == EatingType.MORE) "더먹기" else "덜먹기"
+        mixpanelProvider.sendEvent(GoalEvent.addGoal(goalType), false)
     }
 }

--- a/app/src/main/java/org/keepgoeat/presentation/my/MyActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/my/MyActivity.kt
@@ -10,6 +10,7 @@ import org.keepgoeat.BuildConfig
 import org.keepgoeat.R
 import org.keepgoeat.databinding.ActivityMyBinding
 import org.keepgoeat.presentation.common.WebViewActivity
+import org.keepgoeat.presentation.sign.SignActivity
 import org.keepgoeat.util.binding.BindingActivity
 import timber.log.Timber
 
@@ -24,6 +25,16 @@ class MyActivity : BindingActivity<ActivityMyBinding>(R.layout.activity_my) {
 
         viewModel.fetchUserInfo()
         addListeners()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        viewModel.startRecodingScreenTime()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        viewModel.stopRecodingScreenTime(SCREEN_NAME)
     }
 
     private fun addListeners() {
@@ -113,5 +124,6 @@ class MyActivity : BindingActivity<ActivityMyBinding>(R.layout.activity_my) {
             "https://68space.notion.site/9083a018baab42958103596378417c13"
         const val ARG_HOME_GOAL_COUNT = "homeGoalCount"
         const val ARG_USER_INFO = "userInfo"
+        private const val SCREEN_NAME = "mypage"
     }
 }

--- a/app/src/main/java/org/keepgoeat/presentation/my/MyActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/my/MyActivity.kt
@@ -10,7 +10,6 @@ import org.keepgoeat.BuildConfig
 import org.keepgoeat.R
 import org.keepgoeat.databinding.ActivityMyBinding
 import org.keepgoeat.presentation.common.WebViewActivity
-import org.keepgoeat.presentation.sign.SignActivity
 import org.keepgoeat.util.binding.BindingActivity
 import timber.log.Timber
 

--- a/app/src/main/java/org/keepgoeat/presentation/my/MyViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/my/MyViewModel.kt
@@ -1,6 +1,5 @@
 package org.keepgoeat.presentation.my
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,11 +13,11 @@ import org.keepgoeat.domain.model.UserInfo
 import org.keepgoeat.domain.repository.AuthRepository
 import org.keepgoeat.domain.repository.GoalRepository
 import org.keepgoeat.domain.repository.UserRepository
+import org.keepgoeat.presentation.common.MixpanelViewModel
 import org.keepgoeat.presentation.model.WithdrawReason
 import org.keepgoeat.presentation.type.SortType
 import org.keepgoeat.util.UiState
 import org.keepgoeat.util.extension.toStateFlow
-import org.keepgoeat.util.mixpanel.MixpanelProvider
 import org.keepgoeat.util.mixpanel.SignEvent
 import timber.log.Timber
 import javax.inject.Inject
@@ -30,8 +29,7 @@ class MyViewModel @Inject constructor(
     private val goalRepository: GoalRepository,
     private val userRepository: UserRepository,
     private val localStorage: KGEDataSource,
-    private val mixpanelProvider: MixpanelProvider,
-) : ViewModel() {
+) : MixpanelViewModel() {
     private val _userInfo = MutableStateFlow(UserInfo("", "", 0))
     val userInfo get() = _userInfo.asStateFlow()
 

--- a/app/src/main/java/org/keepgoeat/presentation/my/ServiceIntroActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/my/ServiceIntroActivity.kt
@@ -2,19 +2,33 @@ package org.keepgoeat.presentation.my
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.viewModels
+import dagger.hilt.android.AndroidEntryPoint
 import org.keepgoeat.R
 import org.keepgoeat.databinding.ActivityServiceIntroBinding
 import org.keepgoeat.presentation.common.WebViewActivity
 import org.keepgoeat.presentation.common.WebViewActivity.Companion.ARG_WEB_VIEW_LINK
 import org.keepgoeat.util.binding.BindingActivity
 
+@AndroidEntryPoint
 class ServiceIntroActivity :
     BindingActivity<ActivityServiceIntroBinding>(R.layout.activity_service_intro) {
+    private val viewModel: MyViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         addListeners()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        viewModel.startRecodingScreenTime()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        viewModel.stopRecodingScreenTime(SCREEN_NAME)
     }
 
     private fun addListeners() {
@@ -35,5 +49,6 @@ class ServiceIntroActivity :
     companion object {
         private const val OPEN_SOURCE_LINK =
             "https://68space.notion.site/cd16c9399dfe4c7a867deb59851282e3"
+        private const val SCREEN_NAME = "service intro"
     }
 }

--- a/app/src/main/java/org/keepgoeat/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/onboarding/OnboardingViewModel.kt
@@ -1,16 +1,16 @@
 package org.keepgoeat.presentation.onboarding
 
-import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.keepgoeat.data.datasource.local.KGEDataSource
+import org.keepgoeat.presentation.common.MixpanelViewModel
 import javax.inject.Inject
 
 @HiltViewModel
 class OnboardingViewModel @Inject constructor(private val localStorage: KGEDataSource) :
-    ViewModel() {
-    private val _position = MutableStateFlow<Int>(0)
+    MixpanelViewModel() {
+    private val _position = MutableStateFlow(0)
     val position get() = _position.asStateFlow()
 
     fun setPosition(position: Int) {

--- a/app/src/main/java/org/keepgoeat/presentation/setting/GoalSettingActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/setting/GoalSettingActivity.kt
@@ -14,7 +14,6 @@ import org.keepgoeat.presentation.detail.GoalDetailActivity
 import org.keepgoeat.presentation.detail.GoalDetailActivity.Companion.ARG_GOAL_ID
 import org.keepgoeat.presentation.home.HomeActivity
 import org.keepgoeat.presentation.model.GoalContent
-import org.keepgoeat.presentation.sign.SignActivity
 import org.keepgoeat.presentation.type.EatingType
 import org.keepgoeat.util.UiState
 import org.keepgoeat.util.binding.BindingActivity

--- a/app/src/main/java/org/keepgoeat/presentation/setting/GoalSettingActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/setting/GoalSettingActivity.kt
@@ -14,6 +14,7 @@ import org.keepgoeat.presentation.detail.GoalDetailActivity
 import org.keepgoeat.presentation.detail.GoalDetailActivity.Companion.ARG_GOAL_ID
 import org.keepgoeat.presentation.home.HomeActivity
 import org.keepgoeat.presentation.model.GoalContent
+import org.keepgoeat.presentation.sign.SignActivity
 import org.keepgoeat.presentation.type.EatingType
 import org.keepgoeat.util.UiState
 import org.keepgoeat.util.binding.BindingActivity
@@ -48,6 +49,16 @@ class GoalSettingActivity :
 
         addListeners()
         collectData()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        viewModel.startRecodingScreenTime()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        viewModel.stopRecodingScreenTime(viewModel.eatingType.value?.name?.lowercase() ?: "")
     }
 
     private fun collectData() {

--- a/app/src/main/java/org/keepgoeat/presentation/setting/GoalSettingViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/setting/GoalSettingViewModel.kt
@@ -1,6 +1,5 @@
 package org.keepgoeat.presentation.setting
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -8,11 +7,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.keepgoeat.domain.repository.GoalRepository
+import org.keepgoeat.presentation.common.MixpanelViewModel
 import org.keepgoeat.presentation.model.GoalContent
 import org.keepgoeat.presentation.type.EatingType
 import org.keepgoeat.util.UiState
 import org.keepgoeat.util.mixpanel.GoalEvent
-import org.keepgoeat.util.mixpanel.MixpanelProvider
 import org.keepgoeat.util.safeLet
 import timber.log.Timber
 import javax.inject.Inject
@@ -20,8 +19,7 @@ import javax.inject.Inject
 @HiltViewModel
 class GoalSettingViewModel @Inject constructor(
     private val goalRepository: GoalRepository,
-    private val mixpanelProvider: MixpanelProvider,
-) : ViewModel() {
+) : MixpanelViewModel() {
     val goalFood = MutableStateFlow<String?>(null)
     val goalCriterion = MutableStateFlow<String>("")
     private val _eatingType = MutableStateFlow<EatingType?>(null)

--- a/app/src/main/java/org/keepgoeat/presentation/setting/GoalSettingViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/setting/GoalSettingViewModel.kt
@@ -81,9 +81,4 @@ class GoalSettingViewModel @Inject constructor(
         goalFood.value = goal.food
         goalCriterion.value = goal.criterion
     }
-
-    fun sendGoalAddEvent() { // TODO 목표 추가 버튼 클릭 시 찍기, HomeViewModel로 이동
-        val goalType = if (eatingType.value == EatingType.MORE) "더먹기" else "덜먹기"
-        mixpanelProvider.sendEvent(GoalEvent.addGoal(goalType))
-    }
 }

--- a/app/src/main/java/org/keepgoeat/presentation/sign/SignActivity.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/sign/SignActivity.kt
@@ -35,6 +35,16 @@ class SignActivity : BindingActivity<ActivitySignBinding>(R.layout.activity_sign
         collectData()
     }
 
+    override fun onStart() {
+        super.onStart()
+        viewModel.startRecodingScreenTime()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        viewModel.stopRecodingScreenTime(SCREEN_NAME)
+    }
+
     private fun addListeners() {
         binding.layoutKakaoSignIn.setOnClickListener {
             kakaoSignService.loginKakao(viewModel::login, viewModel::saveAccount)
@@ -67,5 +77,9 @@ class SignActivity : BindingActivity<ActivitySignBinding>(R.layout.activity_sign
             else HomeActivity::class.java
         startActivity(Intent(this, nextScreen))
         finish()
+    }
+
+    companion object {
+        private const val SCREEN_NAME = "signup"
     }
 }

--- a/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
@@ -1,6 +1,5 @@
 package org.keepgoeat.presentation.sign
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,7 +12,6 @@ import org.keepgoeat.domain.repository.AuthRepository
 import org.keepgoeat.presentation.common.MixpanelViewModel
 import org.keepgoeat.presentation.type.LoginPlatformType
 import org.keepgoeat.util.UiState
-import org.keepgoeat.util.mixpanel.MixpanelProvider
 import org.keepgoeat.util.mixpanel.SignEvent
 import javax.inject.Inject
 
@@ -34,7 +32,7 @@ class SignViewModel @Inject constructor(
                 _loginUiState.value = UiState.Success(
                     Pair(it?.type == SIGN_UP, localStorage.isClickedOnboardingButton)
                 )
-                sendSignEventLog(it?.type)
+                sendSignEventLog(it?.type, loginPlatForm.label)
             }.onFailure {
                 _loginUiState.value = UiState.Error(it.message)
             }
@@ -46,10 +44,11 @@ class SignViewModel @Inject constructor(
         localStorage.userEmail = accountInfo.email
     }
 
-    private fun sendSignEventLog(signType: String?) {
+    private fun sendSignEventLog(signType: String?, platform: String) {
         when (signType) {
             SIGN_UP -> {
                 mixpanelProvider.setUser()
+                mixpanelProvider.sendEvent(SignEvent.completeSignUp(platform))
             }
             SIGN_IN -> {
                 mixpanelProvider.sendEvent(SignEvent.completeLogin())

--- a/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
@@ -10,6 +10,7 @@ import org.keepgoeat.data.datasource.local.KGEDataSource
 import org.keepgoeat.data.model.request.RequestAuth
 import org.keepgoeat.domain.model.AccountInfo
 import org.keepgoeat.domain.repository.AuthRepository
+import org.keepgoeat.presentation.common.MixpanelViewModel
 import org.keepgoeat.presentation.type.LoginPlatformType
 import org.keepgoeat.util.UiState
 import org.keepgoeat.util.mixpanel.MixpanelProvider
@@ -20,9 +21,7 @@ import javax.inject.Inject
 class SignViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val localStorage: KGEDataSource,
-    private val mixpanelProvider: MixpanelProvider,
-) :
-    ViewModel() {
+) : MixpanelViewModel() {
     private var _loginUiState = MutableStateFlow<UiState<Pair<Boolean, Boolean>>>(UiState.Loading)
     val loginUiState get() = _loginUiState.asStateFlow()
 

--- a/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
@@ -35,7 +35,7 @@ class SignViewModel @Inject constructor(
                 _loginUiState.value = UiState.Success(
                     Pair(it?.type == SIGN_UP, localStorage.isClickedOnboardingButton)
                 )
-                sendSignEventLog(it?.type, loginPlatForm)
+                sendSignEventLog(it?.type)
             }.onFailure {
                 _loginUiState.value = UiState.Error(it.message)
             }
@@ -47,11 +47,10 @@ class SignViewModel @Inject constructor(
         localStorage.userEmail = accountInfo.email
     }
 
-    private fun sendSignEventLog(signType: String?, platform: LoginPlatformType) {
+    private fun sendSignEventLog(signType: String?) {
         when (signType) {
             SIGN_UP -> {
                 mixpanelProvider.setUser()
-                mixpanelProvider.sendEvent(SignEvent.completeSignUp(platform))
             }
             SIGN_IN -> {
                 mixpanelProvider.sendEvent(SignEvent.completeLogin())

--- a/app/src/main/java/org/keepgoeat/util/mixpanel/GoalEvent.kt
+++ b/app/src/main/java/org/keepgoeat/util/mixpanel/GoalEvent.kt
@@ -12,4 +12,11 @@ object GoalEvent {
         "Add Goal",
         mapOf("Goal Type" to eatingType)
     )
+
+    fun createGoal(title: String, criterion: String) = MixPanelEvent(
+        "Create Goal",
+        mapOf("Goal Name" to title, "Goal Standard" to criterion)
+    )
+
+    fun deleteGoal() = MixPanelEvent("Delete Goal", null)
 }

--- a/app/src/main/java/org/keepgoeat/util/mixpanel/MixpanelProvider.kt
+++ b/app/src/main/java/org/keepgoeat/util/mixpanel/MixpanelProvider.kt
@@ -20,7 +20,15 @@ class MixpanelProvider @Inject constructor(
 
     fun setUser() {
         instance.identify(localStorage.userEmail)
-        instance.people.set(getUserProperties())
+
+        val props = JSONObject().apply {
+            put(PROPERTY_NICKNAME, localStorage.userName)
+            put(PROPERTY_EMAIL, localStorage.userEmail)
+            put(PROPERTY_PLATFORM, localStorage.loginPlatform)
+            put(PROPERTY_GOAL_NUMBER, 0)
+        }
+
+        instance.people.set(props)
     }
 
     private fun getUserProperties() = JSONObject().apply {
@@ -43,5 +51,7 @@ class MixpanelProvider @Inject constructor(
     companion object {
         private const val PROPERTY_NICKNAME = "\$name"
         private const val PROPERTY_EMAIL = "\$email"
+        private const val PROPERTY_PLATFORM = "Platform"
+        private const val PROPERTY_GOAL_NUMBER = "Goal Number"
     }
 }

--- a/app/src/main/java/org/keepgoeat/util/mixpanel/MixpanelProvider.kt
+++ b/app/src/main/java/org/keepgoeat/util/mixpanel/MixpanelProvider.kt
@@ -36,6 +36,14 @@ class MixpanelProvider @Inject constructor(
         put(PROPERTY_EMAIL, localStorage.userEmail)
     }
 
+    fun createGoal() {
+        instance.people.increment(PROPERTY_GOAL_NUMBER, 1.0)
+    }
+
+    fun deleteGoal() {
+        instance.people.increment(PROPERTY_GOAL_NUMBER, -1.0)
+    }
+
     /** 믹스패널에 이벤트를 전송하는 함수. 유저 프로퍼티를 함께 전송해야하는 경우, isRequiredUserProps를 false로 설정 필요 */
     fun sendEvent(event: MixPanelEvent, isRequiredUserProps: Boolean = true) {
         val props = if (isRequiredUserProps) getUserProperties() else JSONObject()

--- a/app/src/main/java/org/keepgoeat/util/mixpanel/MixpanelProvider.kt
+++ b/app/src/main/java/org/keepgoeat/util/mixpanel/MixpanelProvider.kt
@@ -15,7 +15,7 @@ class MixpanelProvider @Inject constructor(
     @ApplicationContext private val context: Context,
     private val localStorage: KGEDataSource,
 ) {
-    private var instance: MixpanelAPI =
+    private val instance: MixpanelAPI =
         MixpanelAPI.getInstance(context, BuildConfig.MIXPANEL_PROJECT_TOKEN, true)
 
     fun setUser() {
@@ -24,7 +24,7 @@ class MixpanelProvider @Inject constructor(
         val props = JSONObject().apply {
             put(PROPERTY_NICKNAME, localStorage.userName)
             put(PROPERTY_EMAIL, localStorage.userEmail)
-            put(PROPERTY_PLATFORM, localStorage.loginPlatform)
+            put(PROPERTY_PLATFORM, localStorage.loginPlatform.label)
             put(PROPERTY_GOAL_NUMBER, 0)
         }
 

--- a/app/src/main/java/org/keepgoeat/util/mixpanel/MixpanelProvider.kt
+++ b/app/src/main/java/org/keepgoeat/util/mixpanel/MixpanelProvider.kt
@@ -56,10 +56,26 @@ class MixpanelProvider @Inject constructor(
         instance.track(event.name, props)
     }
 
+    fun startRecodingScreenTime() {
+        instance.timeEvent(EVENT_VIEW_PAGE)
+    }
+
+    fun stopRecodingScreenTime(screenName: String) {
+        val props = JSONObject().apply {
+            put(PROPERTY_PAGE_NAME, screenName)
+        }
+        instance.track(EVENT_VIEW_PAGE, props)
+    }
+
     companion object {
+        // User Property
         private const val PROPERTY_NICKNAME = "\$name"
         private const val PROPERTY_EMAIL = "\$email"
         private const val PROPERTY_PLATFORM = "Platform"
         private const val PROPERTY_GOAL_NUMBER = "Goal Number"
+
+        // Event Property
+        private const val EVENT_VIEW_PAGE = "View Page"
+        private const val PROPERTY_PAGE_NAME = "Page Name"
     }
 }

--- a/app/src/main/java/org/keepgoeat/util/mixpanel/SignEvent.kt
+++ b/app/src/main/java/org/keepgoeat/util/mixpanel/SignEvent.kt
@@ -3,6 +3,8 @@ package org.keepgoeat.util.mixpanel
 import org.keepgoeat.presentation.model.MixPanelEvent
 
 object SignEvent {
+    fun completeSignUp(platForm: String) = MixPanelEvent("Sign Up", mapOf("Platform" to platForm))
+
     fun completeLogin() = MixPanelEvent("Login", null)
 
     fun deleteAccount(reasons: Map<String, Any>?) = MixPanelEvent("Delete Account", reasons)

--- a/app/src/main/java/org/keepgoeat/util/mixpanel/SignEvent.kt
+++ b/app/src/main/java/org/keepgoeat/util/mixpanel/SignEvent.kt
@@ -4,9 +4,6 @@ import org.keepgoeat.presentation.model.MixPanelEvent
 import org.keepgoeat.presentation.type.LoginPlatformType
 
 object SignEvent {
-    fun completeSignUp(platform: LoginPlatformType) =
-        MixPanelEvent("Sign Up", mapOf("Platform" to platform.label))
-
     fun completeLogin() = MixPanelEvent("Login", null)
 
     fun deleteAccount(reasons: Map<String, Any>?) = MixPanelEvent("Delete Account", reasons)

--- a/app/src/main/java/org/keepgoeat/util/mixpanel/SignEvent.kt
+++ b/app/src/main/java/org/keepgoeat/util/mixpanel/SignEvent.kt
@@ -1,7 +1,6 @@
 package org.keepgoeat.util.mixpanel
 
 import org.keepgoeat.presentation.model.MixPanelEvent
-import org.keepgoeat.presentation.type.LoginPlatformType
 
 object SignEvent {
     fun completeLogin() = MixPanelEvent("Login", null)


### PR DESCRIPTION
## Related issue 🛠
- #214

## Work Description ✏️
- 회원가입 시 로그인 플랫폼, 목표 수 유저 프로퍼티 추가
- Goal Create(목표 추가 성공), Goal Delete(목표 삭제 성공) 시 이벤트 찍기
- 기존 Goal Add 이벤트를 목표 추가 성공 시 -> 더먹기, 덜먹기 버튼 클릭 시 전송하는 것으로 수정
- 각 뷰별 체류시간 및 뷰 조회 로그 찍기 구현

## Uncompleted Tasks 😅
- [x] 뷰 체류시간, 뷰 조회
- [x] 현재 로그인 타임아웃 이슈로 테스트가 어려워 해결된 후 테스트 할 예정
