### PR TITLE
[mod] 온보딩 중도 이탈 플로우 개선

### DIFF
--- a/app/src/main/java/org/keepgoeat/data/model/response/ResponseAuth.kt
+++ b/app/src/main/java/org/keepgoeat/data/model/response/ResponseAuth.kt
@@ -1,6 +1,9 @@
 package org.keepgoeat.data.model.response
 
 import kotlinx.serialization.Serializable
+import org.keepgoeat.domain.model.AuthInfo
+import org.keepgoeat.domain.type.SignType.SIGN_IN
+import org.keepgoeat.domain.type.SignType.SIGN_UP
 
 @Serializable
 data class ResponseAuth(
@@ -15,5 +18,12 @@ data class ResponseAuth(
         val email: String,
         val accessToken: String,
         val refreshToken: String,
-    )
+    ) {
+        fun toAuthInfo() = AuthInfo(
+            if (type == SIGN_UP.typeStr) SIGN_UP else SIGN_IN,
+            email,
+            accessToken,
+            refreshToken
+        )
+    }
 }

--- a/app/src/main/java/org/keepgoeat/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/org/keepgoeat/data/repository/AuthRepositoryImpl.kt
@@ -3,10 +3,11 @@ package org.keepgoeat.data.repository
 import org.keepgoeat.data.datasource.local.KGEDataSource
 import org.keepgoeat.data.datasource.remote.AuthDataSource
 import org.keepgoeat.data.model.request.RequestAuth
-import org.keepgoeat.data.model.response.ResponseAuth
 import org.keepgoeat.data.model.response.ResponseRefresh
 import org.keepgoeat.data.model.response.ResponseWithdraw
+import org.keepgoeat.domain.model.AuthInfo
 import org.keepgoeat.domain.repository.AuthRepository
+import org.keepgoeat.domain.type.SignType
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -14,15 +15,18 @@ class AuthRepositoryImpl @Inject constructor(
     private val authDataSource: AuthDataSource,
     private val localStorage: KGEDataSource,
 ) : AuthRepository {
-    override suspend fun login(requestAuth: RequestAuth): Result<ResponseAuth.ResponseAuthData?> =
+    override suspend fun login(requestAuth: RequestAuth): Result<AuthInfo?> =
         runCatching {
-            authDataSource.login(requestAuth).data
+            authDataSource.login(requestAuth).data?.toAuthInfo()
         }.onSuccess {
             with(localStorage) {
                 isLogin = true
                 it?.let {
                     accessToken = it.accessToken
                     refreshToken = it.refreshToken
+
+                    if (it.signType == SignType.SIGN_IN)
+                        isClickedOnboardingButton = true
                 }
             }
         }.onFailure {

--- a/app/src/main/java/org/keepgoeat/domain/model/AuthInfo.kt
+++ b/app/src/main/java/org/keepgoeat/domain/model/AuthInfo.kt
@@ -1,0 +1,10 @@
+package org.keepgoeat.domain.model
+
+import org.keepgoeat.domain.type.SignType
+
+data class AuthInfo(
+    val signType: SignType,
+    val email: String,
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/app/src/main/java/org/keepgoeat/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/org/keepgoeat/domain/repository/AuthRepository.kt
@@ -1,12 +1,12 @@
 package org.keepgoeat.domain.repository
 
 import org.keepgoeat.data.model.request.RequestAuth
-import org.keepgoeat.data.model.response.ResponseAuth
 import org.keepgoeat.data.model.response.ResponseRefresh
 import org.keepgoeat.data.model.response.ResponseWithdraw
+import org.keepgoeat.domain.model.AuthInfo
 
 interface AuthRepository {
-    suspend fun login(requestAuth: RequestAuth): Result<ResponseAuth.ResponseAuthData?>
+    suspend fun login(requestAuth: RequestAuth): Result<AuthInfo?>
     suspend fun refresh(): Result<ResponseRefresh.ResponseToken?>
     suspend fun deleteAccount(): Result<ResponseWithdraw>
 }

--- a/app/src/main/java/org/keepgoeat/domain/type/SignType.kt
+++ b/app/src/main/java/org/keepgoeat/domain/type/SignType.kt
@@ -1,0 +1,5 @@
+package org.keepgoeat.domain.type
+
+enum class SignType(val typeStr: String) {
+    SIGN_UP("signup"), SIGN_IN("signin")
+}

--- a/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
@@ -31,8 +31,7 @@ class SignViewModel @Inject constructor(
                 RequestAuth(accessToken, loginPlatForm.name)
             ).onSuccess {
                 _loginUiState.value = UiState.Success(
-                    Pair(it?.signType == SignType.SIGN_UP,
-                        localStorage.isClickedOnboardingButton)
+                    Pair(it?.signType == SignType.SIGN_UP, localStorage.isClickedOnboardingButton)
                 )
                 sendSignEventLog(it?.signType, loginPlatForm.label)
             }.onFailure {

--- a/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/sign/SignViewModel.kt
@@ -9,6 +9,7 @@ import org.keepgoeat.data.datasource.local.KGEDataSource
 import org.keepgoeat.data.model.request.RequestAuth
 import org.keepgoeat.domain.model.AccountInfo
 import org.keepgoeat.domain.repository.AuthRepository
+import org.keepgoeat.domain.type.SignType
 import org.keepgoeat.presentation.base.viewmodel.MixpanelViewModel
 import org.keepgoeat.presentation.type.LoginPlatformType
 import org.keepgoeat.util.UiState
@@ -30,9 +31,10 @@ class SignViewModel @Inject constructor(
                 RequestAuth(accessToken, loginPlatForm.name)
             ).onSuccess {
                 _loginUiState.value = UiState.Success(
-                    Pair(it?.type == SIGN_UP, localStorage.isClickedOnboardingButton)
+                    Pair(it?.signType == SignType.SIGN_UP,
+                        localStorage.isClickedOnboardingButton)
                 )
-                sendSignEventLog(it?.type, loginPlatForm.label)
+                sendSignEventLog(it?.signType, loginPlatForm.label)
             }.onFailure {
                 _loginUiState.value = UiState.Error(it.message)
             }
@@ -44,20 +46,16 @@ class SignViewModel @Inject constructor(
         localStorage.userEmail = accountInfo.email
     }
 
-    private fun sendSignEventLog(signType: String?, platform: String) {
+    private fun sendSignEventLog(signType: SignType?, platform: String) {
         when (signType) {
-            SIGN_UP -> {
+            SignType.SIGN_UP -> {
                 mixpanelProvider.setUser()
                 mixpanelProvider.sendEvent(SignEvent.completeSignUp(platform))
             }
-            SIGN_IN -> {
+            SignType.SIGN_IN -> {
                 mixpanelProvider.sendEvent(SignEvent.completeLogin())
             }
+            else -> {}
         }
-    }
-
-    companion object {
-        private const val SIGN_UP = "signup"
-        private const val SIGN_IN = "signin"
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #236

## Work Description ✏️
- 앱 및 앱 데이터 삭제, 다른 기기 로그인 등의 특수 경우 발생 시 온보딩을 중도 이탈해도 온보딩을 다시 띄우지 않도록 구현
   - 위와 같은 특수 상황이 발생한 후 로그인 과정을 거치게 되고, 로그인 성공 시 온보딩을 확인한 것으로 간주함. 

