### PR TITLE
[fix] 토큰 갱신 시 크래시가 발생하는 버그 수정

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,6 +95,7 @@ dependencies {
     // Firebase
     implementation platform('com.google.firebase:firebase-bom:31.1.1')
     implementation 'com.google.firebase:firebase-crashlytics-ktx'
+    implementation 'com.google.firebase:firebase-analytics-ktx'
 
     // Mixpanel
     implementation 'com.mixpanel.android:mixpanel-android:7.+'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,7 +91,6 @@ dependencies {
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1'
-    implementation 'com.google.code.gson:gson:2.10'
 
     // Firebase
     implementation platform('com.google.firebase:firebase-bom:31.1.1')

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,8 +21,8 @@ android {
         applicationId "org.keepgoeat"
         minSdk 28
         targetSdk 33
-        versionCode 16
-        versionName "1.0.0"
+        versionCode 17
+        versionName "1.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "KGE_BASE_URL", properties["KGE_BASE_URL"]

--- a/app/src/main/java/org/keepgoeat/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/org/keepgoeat/data/interceptor/AuthInterceptor.kt
@@ -2,11 +2,12 @@ package org.keepgoeat.data.interceptor
 
 import android.app.Application
 import android.content.Intent
-import com.google.gson.Gson
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
@@ -46,6 +47,8 @@ class AuthInterceptor @Inject constructor(
                         accessToken = responseRefresh.data.accessToken
                         refreshToken = responseRefresh.data.refreshToken
                     }
+                    refreshTokenResponse.close()
+
                     val newRequest = originalRequest.newAuthBuilder().build()
                     return chain.proceed(newRequest)
                 } else {

--- a/app/src/main/java/org/keepgoeat/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/org/keepgoeat/data/interceptor/AuthInterceptor.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.content.Intent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
@@ -63,7 +62,6 @@ class AuthInterceptor @Inject constructor(
                             )
                             showToast(getString(R.string.auto_login_failure))
                             localStorage.clear()
-                            cancel()
                         }
                     }
                 }

--- a/app/src/main/java/org/keepgoeat/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/org/keepgoeat/data/interceptor/AuthInterceptor.kt
@@ -19,8 +19,8 @@ import org.keepgoeat.util.extension.showToast
 import javax.inject.Inject
 
 class AuthInterceptor @Inject constructor(
+    private val json: Json,
     private val localStorage: KGEDataSource,
-    private val gson: Gson,
     private val context: Application,
 ) : Interceptor {
 
@@ -39,10 +39,12 @@ class AuthInterceptor @Inject constructor(
                 val refreshTokenResponse = chain.proceed(refreshTokenRequest)
 
                 if (refreshTokenResponse.isSuccessful) {
-                    val responseRefresh = gson.fromJson(
-                        refreshTokenResponse.body?.string(),
-                        ResponseRefresh::class.java
-                    )
+                    val responseRefresh =
+                        json.decodeFromString<ResponseRefresh>(
+                            refreshTokenResponse.body?.string()
+                                ?: throw IllegalStateException("refreshTokenResponse is null $refreshTokenResponse")
+                        )
+
                     with(localStorage) {
                         accessToken = responseRefresh.data.accessToken
                         refreshToken = responseRefresh.data.refreshToken

--- a/app/src/main/java/org/keepgoeat/di/NetworkModule.kt
+++ b/app/src/main/java/org/keepgoeat/di/NetworkModule.kt
@@ -1,7 +1,5 @@
 package org.keepgoeat.di
 
-import com.google.gson.Gson
-import com.google.gson.GsonBuilder
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
 import dagger.Provides
@@ -32,10 +30,6 @@ object NetworkModule {
         explicitNulls = false
         ignoreUnknownKeys = true
     }
-
-    @Provides
-    @Singleton
-    fun provideGson(): Gson = GsonBuilder().setLenient().create()
 
     @ExperimentalSerializationApi
     @Provides

--- a/app/src/main/java/org/keepgoeat/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/org/keepgoeat/presentation/home/HomeViewModel.kt
@@ -125,7 +125,7 @@ class HomeViewModel @Inject constructor(
         val splitCurrent = BuildConfig.VERSION_NAME.split(".")
         val splitUpdate = updateVersion.split(".")
         if (splitCurrent.size > 2 && splitUpdate.size > 2) {
-            if (splitCurrent[2] != splitUpdate[2]) return true
+            if (splitCurrent[2] < splitUpdate[2]) return true
         }
 
         return false

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.2'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.5'
         classpath 'com.google.gms:google-services:4.3.14'
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #243

## Work Description ✏️
   - 토큰 갱신 시 크래시가 발생하는 버그 수정
      - **new request 전에 previous response를 close하지 않아 발생하는 버그**로 `refreshTokenResponse.close()`를 추가
   - 토큰 갱신과정에서 response json을 data class로 변환하는 과정에서 사용하는 **gson을 json으로 변경**
      - 레트로핏 컨버터로 json을 사용하고 있는데 토큰 리프레시 요청 시에만 gson으로 사용하고 있음.
      - json으로 통일하고 gson라이브러리는 삭제함.
   - 파이어베이스 **analytics 라이브러리 추가**
      - 크래시리틱스에서 **비정상 종료 미발생 통계를 조회**하기 위함
   - 버전 코드 및 네임을 업데이트
      - 핫픽스로 강제 업데이트를 위함 

## Screenshot 📸
파이어베이스 비정상 종료 이벤트 요약
<img width="761" alt="image" src="https://github.com/Team-KeepGoEat/KeepGoEat-AOS/assets/48701368/6bbcc71b-8720-483f-93ab-e2cc5a87c575">
