### PR TITLE
[fix] 토큰 갱신 요청 전 reponse를 close하지 않아 크래시가 발생하는 버그 수정

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ android {
         applicationId "org.keepgoeat"
         minSdk 28
         targetSdk 33
-        versionCode 18
+        versionCode 19
         versionName "1.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     implementation 'com.jakewharton.timber:timber:5.0.1'
 
     // Network
-    implementation platform('com.squareup.okhttp3:okhttp-bom:4.10.0')
+    implementation platform('com.squareup.okhttp3:okhttp-bom:4.11.0')
     implementation 'com.squareup.okhttp3:okhttp'
     implementation 'com.squareup.okhttp3:logging-interceptor'
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'

--- a/app/src/main/java/org/keepgoeat/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/org/keepgoeat/data/interceptor/AuthInterceptor.kt
@@ -31,6 +31,7 @@ class AuthInterceptor @Inject constructor(
 
         when (response.code) {
             401 -> {
+                response.close()
                 val refreshTokenRequest = originalRequest.newBuilder().get()
                     .url("${BuildConfig.KGE_BASE_URL}auth/refresh")
                     .addHeader(ACCESS_TOKEN, localStorage.accessToken)

--- a/app/src/main/java/org/keepgoeat/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/org/keepgoeat/data/interceptor/AuthInterceptor.kt
@@ -25,7 +25,8 @@ class AuthInterceptor @Inject constructor(
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
-        val authRequest = originalRequest.newAuthBuilder().build()
+        val authRequest =
+            if (!localStorage.isLogin) originalRequest else originalRequest.newAuthBuilder().build()
         val response = chain.proceed(authRequest)
 
         when (response.code) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,6 @@
 <resources>
     <string name="app_name">KeepGoEat</string>
     <string name="dummy_upload">upload</string>
-    <string name="app_version">1.0.0</string>
     <string name="keep_go_eat_mail">Keepgo2at@gmail.com</string>
     <string name="play_store_detail_url">market://details?id=</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">KeepGoEat</string>
     <string name="dummy_upload">upload</string>
-    <string name="keep_go_eat_mail">Keepgo2at@gmail.com</string>
+    <string name="keep_go_eat_mail">keepgo2at@gmail.com</string>
     <string name="play_store_detail_url">market://details?id=</string>
 
     <!-- Global -->


### PR DESCRIPTION
## Related issue 🛠
- closed #243

## Work Description ✏️
- 토큰 갱신 요청 전 reponse를 close하지 않아 크래시가 발생하는 버그 수정
- okhttp-bom 라이브러리 버전 4.10.0 -> 4.11.0로 버전업
- 로그인 여부에 따라 authRequest 생성 분기 처리
- 버전 코드 18 -> 19로 변경
- 앱 문의 사항에서 사용하는 이메일 주소 변경
- 불필요한 스트링 리소스 삭제
   - 버전 정보 스트링 리소스 삭제 (BuildConfig.VERSION_NAME을 사용하는 것으로 변경하면서 필요없게 됨)
